### PR TITLE
Revert PR #1 commits to prepare for testcontainers integration

### DIFF
--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -52,7 +52,6 @@ type MessageRequest struct {
 	PostID         string           `json:"post_id"`           // Optional: Mattermost post ID metadata
 	Files          []FileAttachment `json:"files"`             // Optional: File attachments
 	ReplyToEventID string           `json:"reply_to_event_id"` // Optional: Event ID to reply to (for files)
-	Mentions       map[string]any   `json:"mentions"`          // Optional: Matrix mentions structure (m.mentions)
 }
 
 // SendEventResponse represents the response from Matrix when sending events.
@@ -988,11 +987,6 @@ func (c *Client) sendTextMessage(req MessageRequest, rootEventID string) (*SendE
 		content["mattermost_remote_id"] = c.remoteID
 	}
 
-	// Add mentions if provided
-	if len(req.Mentions) > 0 {
-		content["m.mentions"] = req.Mentions
-	}
-
 	return c.sendEventAsUser(req.RoomID, "m.room.message", content, req.GhostUserID)
 }
 
@@ -1040,11 +1034,6 @@ func (c *Client) sendFileMessage(req MessageRequest, file FileAttachment, rootEv
 	}
 	if c.remoteID != "" {
 		content["mattermost_remote_id"] = c.remoteID
-	}
-
-	// Add mentions if provided
-	if len(req.Mentions) > 0 {
-		content["m.mentions"] = req.Mentions
 	}
 
 	return c.sendEventAsUser(req.RoomID, "m.room.message", content, req.GhostUserID)

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -1276,6 +1276,7 @@ func (c *Client) DownloadFile(mxcURI string, maxSize int64, contentTypePrefix st
 	return nil, errors.Wrapf(lastErr, "failed to download file from any endpoint for MXC URI: %s", mxcURI)
 }
 
+
 // PublishRoomToDirectory explicitly publishes a room to the public directory
 func (c *Client) PublishRoomToDirectory(roomID string, publish bool) error {
 	if c.asToken == "" {

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -1182,19 +1182,19 @@ func (c *Client) GetUserProfile(userID string) (*UserProfile, error) {
 	return &profile, nil
 }
 
-// DownloadFile downloads file data from a Matrix MXC URI with configurable size limit
-func (c *Client) DownloadFile(mxcURI string, maxSize int64, contentTypePrefix string) ([]byte, error) {
-	if mxcURI == "" {
-		return nil, errors.New("MXC URI is empty")
+// DownloadAvatar downloads avatar image data from a Matrix MXC URI
+func (c *Client) DownloadAvatar(avatarURL string) ([]byte, error) {
+	if avatarURL == "" {
+		return nil, errors.New("avatar URL is empty")
 	}
 
-	// Matrix file URIs are in the format mxc://server/media_id
-	if !strings.HasPrefix(mxcURI, "mxc://") {
-		return nil, errors.New("invalid Matrix MXC URI format")
+	// Matrix avatar URLs are in the format mxc://server/media_id
+	if !strings.HasPrefix(avatarURL, "mxc://") {
+		return nil, errors.New("invalid Matrix avatar URL format")
 	}
 
 	// Extract server and media ID from mxc://server/media_id
-	mxcParts := strings.TrimPrefix(mxcURI, "mxc://")
+	mxcParts := strings.TrimPrefix(avatarURL, "mxc://")
 	parts := strings.SplitN(mxcParts, "/", 2)
 	if len(parts) != 2 {
 		return nil, errors.New("invalid Matrix MXC URI format")
@@ -1219,11 +1219,11 @@ func (c *Client) DownloadFile(mxcURI string, maxSize int64, contentTypePrefix st
 
 	var lastErr error
 	for i, downloadURL := range downloadURLs {
-		c.api.LogDebug("Attempting to download Matrix file", "url", downloadURL, "attempt", i+1, "mxc_uri", mxcURI)
+		c.api.LogDebug("Attempting to download Matrix avatar", "url", downloadURL, "attempt", i+1)
 
 		req, err := http.NewRequest("GET", downloadURL, nil)
 		if err != nil {
-			c.api.LogWarn("Failed to create file download request", "error", err, "url", downloadURL)
+			c.api.LogWarn("Failed to create avatar download request", "error", err, "url", downloadURL)
 			lastErr = err
 			continue
 		}
@@ -1233,7 +1233,7 @@ func (c *Client) DownloadFile(mxcURI string, maxSize int64, contentTypePrefix st
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
-			c.api.LogWarn("Failed to download file from URL", "error", err, "url", downloadURL)
+			c.api.LogWarn("Failed to download avatar from URL", "error", err, "url", downloadURL)
 			lastErr = err
 			continue
 		}
@@ -1245,37 +1245,37 @@ func (c *Client) DownloadFile(mxcURI string, maxSize int64, contentTypePrefix st
 			continue
 		}
 
-		// Check content type if specified
+		// Check content type
 		contentType := resp.Header.Get("Content-Type")
-		if contentTypePrefix != "" && !strings.HasPrefix(contentType, contentTypePrefix) {
-			c.api.LogWarn("Invalid content type", "content_type", contentType, "expected_prefix", contentTypePrefix, "url", downloadURL)
-			lastErr = fmt.Errorf("invalid content type: %s (expected prefix: %s)", contentType, contentTypePrefix)
+		if !strings.HasPrefix(contentType, "image/") {
+			c.api.LogWarn("Invalid content type for avatar", "content_type", contentType, "url", downloadURL)
+			lastErr = fmt.Errorf("invalid content type: %s", contentType)
 			continue
 		}
 
-		// Read the file data
-		fileData, err := io.ReadAll(resp.Body)
+		// Read the image data
+		avatarData, err := io.ReadAll(resp.Body)
 		if err != nil {
-			c.api.LogWarn("Failed to read file data", "error", err, "url", downloadURL)
+			c.api.LogWarn("Failed to read avatar data", "error", err, "url", downloadURL)
 			lastErr = err
 			continue
 		}
 
-		// Check size limit
-		if maxSize > 0 && int64(len(fileData)) > maxSize {
-			c.api.LogWarn("File too large", "size", len(fileData), "max", maxSize, "url", downloadURL)
-			lastErr = fmt.Errorf("file too large: %d bytes (max %d)", len(fileData), maxSize)
+		// Check size limit (6MB max for Mattermost)
+		const maxAvatarSize = 6 * 1024 * 1024
+		if len(avatarData) > maxAvatarSize {
+			c.api.LogWarn("Avatar too large", "size", len(avatarData), "max", maxAvatarSize, "url", downloadURL)
+			lastErr = fmt.Errorf("avatar too large: %d bytes (max %d)", len(avatarData), maxAvatarSize)
 			continue
 		}
 
-		c.api.LogDebug("Successfully downloaded Matrix file", "url", downloadURL, "size", len(fileData), "content_type", contentType, "mxc_uri", mxcURI)
-		return fileData, nil
+		c.api.LogDebug("Successfully downloaded Matrix avatar", "url", downloadURL, "size", len(avatarData), "content_type", contentType)
+		return avatarData, nil
 	}
 
 	// If we get here, all attempts failed
-	return nil, errors.Wrapf(lastErr, "failed to download file from any endpoint for MXC URI: %s", mxcURI)
+	return nil, errors.Wrapf(lastErr, "failed to download avatar from any endpoint for MXC URI: %s", avatarURL)
 }
-
 
 // PublishRoomToDirectory explicitly publishes a room to the public directory
 func (c *Client) PublishRoomToDirectory(roomID string, publish bool) error {

--- a/server/matrix_util.go
+++ b/server/matrix_util.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -571,4 +572,74 @@ func (p *Plugin) downloadMatrixFile(mxcURL string) ([]byte, error) {
 
 	// Delegate to the Matrix client's download method with plugin's max file size
 	return p.matrixClient.DownloadFile(mxcURL, p.maxFileSize, "")
+}
+
+// detectMimeType attempts to detect the MIME type of a file based on filename and content
+func (p *Plugin) detectMimeType(filename string, fileData []byte) string {
+	// Common MIME type mappings based on file extension
+	extension := strings.ToLower(filepath.Ext(filename))
+
+	switch extension {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".svg":
+		return "image/svg+xml"
+	case ".mp4":
+		return "video/mp4"
+	case ".webm":
+		return "video/webm"
+	case ".avi":
+		return "video/x-msvideo"
+	case ".mov":
+		return "video/quicktime"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".ogg":
+		return "audio/ogg"
+	case ".pdf":
+		return "application/pdf"
+	case ".txt":
+		return "text/plain"
+	case ".html":
+		return "text/html"
+	case ".json":
+		return "application/json"
+	case ".xml":
+		return "application/xml"
+	case ".zip":
+		return "application/zip"
+	default:
+		// Try to detect based on file content
+		if len(fileData) > 0 {
+			// Check for common image file signatures
+			if len(fileData) >= 4 {
+				// PNG signature
+				if fileData[0] == 0x89 && fileData[1] == 0x50 && fileData[2] == 0x4E && fileData[3] == 0x47 {
+					return "image/png"
+				}
+				// JPEG signature
+				if fileData[0] == 0xFF && fileData[1] == 0xD8 {
+					return "image/jpeg"
+				}
+				// GIF signature
+				if fileData[0] == 0x47 && fileData[1] == 0x49 && fileData[2] == 0x46 {
+					return "image/gif"
+				}
+				// WebP signature
+				if len(fileData) >= 12 && fileData[0] == 0x52 && fileData[1] == 0x49 && fileData[2] == 0x46 && fileData[3] == 0x46 &&
+					fileData[8] == 0x57 && fileData[9] == 0x45 && fileData[10] == 0x42 && fileData[11] == 0x50 {
+					return "image/webp"
+				}
+			}
+		}
+		return "application/octet-stream"
+	}
 }

--- a/server/matrix_util.go
+++ b/server/matrix_util.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -562,84 +561,4 @@ func cleanupMarkdown(markdown string) string {
 	cleaned = strings.TrimSpace(cleaned)
 
 	return cleaned
-}
-
-// downloadMatrixFile downloads a file from Matrix using the MXC URI
-func (p *Plugin) downloadMatrixFile(mxcURL string) ([]byte, error) {
-	if p.matrixClient == nil {
-		return nil, errors.New("Matrix client not configured")
-	}
-
-	// Delegate to the Matrix client's download method with plugin's max file size
-	return p.matrixClient.DownloadFile(mxcURL, p.maxFileSize, "")
-}
-
-// detectMimeType attempts to detect the MIME type of a file based on filename and content
-func (p *Plugin) detectMimeType(filename string, fileData []byte) string {
-	// Common MIME type mappings based on file extension
-	extension := strings.ToLower(filepath.Ext(filename))
-
-	switch extension {
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".png":
-		return "image/png"
-	case ".gif":
-		return "image/gif"
-	case ".webp":
-		return "image/webp"
-	case ".svg":
-		return "image/svg+xml"
-	case ".mp4":
-		return "video/mp4"
-	case ".webm":
-		return "video/webm"
-	case ".avi":
-		return "video/x-msvideo"
-	case ".mov":
-		return "video/quicktime"
-	case ".mp3":
-		return "audio/mpeg"
-	case ".wav":
-		return "audio/wav"
-	case ".ogg":
-		return "audio/ogg"
-	case ".pdf":
-		return "application/pdf"
-	case ".txt":
-		return "text/plain"
-	case ".html":
-		return "text/html"
-	case ".json":
-		return "application/json"
-	case ".xml":
-		return "application/xml"
-	case ".zip":
-		return "application/zip"
-	default:
-		// Try to detect based on file content
-		if len(fileData) > 0 {
-			// Check for common image file signatures
-			if len(fileData) >= 4 {
-				// PNG signature
-				if fileData[0] == 0x89 && fileData[1] == 0x50 && fileData[2] == 0x4E && fileData[3] == 0x47 {
-					return "image/png"
-				}
-				// JPEG signature
-				if fileData[0] == 0xFF && fileData[1] == 0xD8 {
-					return "image/jpeg"
-				}
-				// GIF signature
-				if fileData[0] == 0x47 && fileData[1] == 0x49 && fileData[2] == 0x46 {
-					return "image/gif"
-				}
-				// WebP signature
-				if len(fileData) >= 12 && fileData[0] == 0x52 && fileData[1] == 0x49 && fileData[2] == 0x46 && fileData[3] == 0x46 &&
-					fileData[8] == 0x57 && fileData[9] == 0x45 && fileData[10] == 0x42 && fileData[11] == 0x50 {
-					return "image/webp"
-				}
-			}
-		}
-		return "application/octet-stream"
-	}
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -16,13 +16,6 @@ import (
 	"github.com/wiggin77/mattermost-plugin-matrix-bridge/server/store/kvstore"
 )
 
-const (
-	// DefaultMaxProfileImageSize is the default maximum size for profile images (6MB)
-	DefaultMaxProfileImageSize = 6 * 1024 * 1024
-	// DefaultMaxFileSize is the default maximum size for file attachments (50MB)
-	DefaultMaxFileSize = 50 * 1024 * 1024
-)
-
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
 type Plugin struct {
 	plugin.MattermostPlugin
@@ -59,12 +52,6 @@ type Plugin struct {
 
 	// Logr instance specifically for logging Matrix transactions.
 	transactionLogger logr.Logger
-
-	// maxProfileImageSize is the maximum size for profile images in bytes
-	maxProfileImageSize int64
-
-	// maxFileSize is the maximum size for file attachments in bytes
-	maxFileSize int64
 }
 
 // OnActivate is invoked when the plugin is activated. If an error is returned, the plugin will be deactivated.
@@ -81,10 +68,6 @@ func (p *Plugin) OnActivate() error {
 
 	p.postTracker = NewPostTracker(DefaultPostTrackerMaxEntries)
 	p.pendingFiles = NewPendingFileTracker()
-
-	// Initialize file size limits with default values
-	p.maxProfileImageSize = DefaultMaxProfileImageSize
-	p.maxFileSize = DefaultMaxFileSize
 
 	p.initMatrixClient()
 

--- a/server/sync_to_matrix.go
+++ b/server/sync_to_matrix.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/pkg/errors"
@@ -191,7 +190,6 @@ func (p *Plugin) createPostInMatrix(post *model.Post, matrixRoomID string, user 
 	// Extract content from message structure
 	finalPlainText := messageContent["body"].(string)
 	finalHTMLContent, _ := messageContent["formatted_body"].(string)
-	mentions, _ := messageContent["m.mentions"].(map[string]any)
 
 	// Send message using consolidated method
 	messageRequest := matrix.MessageRequest{
@@ -202,7 +200,6 @@ func (p *Plugin) createPostInMatrix(post *model.Post, matrixRoomID string, user 
 		ThreadEventID: threadEventID,
 		PostID:        post.Id,
 		Files:         fileAttachments,
-		Mentions:      mentions,
 	}
 
 	sendResponse, err := p.matrixClient.SendMessage(messageRequest)
@@ -620,9 +617,8 @@ func (p *Plugin) extractMattermostMentions(post *model.Post) *MattermostMentionR
 	results := &MattermostMentionResults{}
 
 	// Extract @username mentions (similar to Mattermost's regex)
-	// Match @word where word contains letters, numbers, dots, hyphens, underscores, and colons
-	// Include colon to support bridged usernames like "matrix:username"
-	userMentionRegex := regexp.MustCompile(`@([a-zA-Z0-9\.\-_:]+)`)
+	// Match @word where word contains letters, numbers, dots, hyphens, underscores
+	userMentionRegex := regexp.MustCompile(`@([a-zA-Z0-9\.\-_]+)`)
 	matches := userMentionRegex.FindAllStringSubmatch(text, -1)
 
 	for _, match := range matches {
@@ -637,17 +633,14 @@ func (p *Plugin) extractMattermostMentions(post *model.Post) *MattermostMentionR
 		}
 	}
 
-	p.API.LogDebug("Extracted mentions from Mattermost post", "post_id", post.Id, "message", text, "user_mentions", results.UserMentions, "channel_mentions", results.ChannelMentions)
+	p.API.LogDebug("Extracted mentions from Mattermost post", "post_id", post.Id, "user_mentions", results.UserMentions, "channel_mentions", results.ChannelMentions)
 	return results
 }
 
 // addMatrixMentionsWithData converts Mattermost mentions to Matrix format using pre-extracted mention data
 func (p *Plugin) addMatrixMentionsWithData(content map[string]any, post *model.Post, mentions *MattermostMentionResults) {
-	p.API.LogDebug("Processing mentions for Matrix", "post_id", post.Id, "user_mentions_count", len(mentions.UserMentions), "user_mentions", mentions.UserMentions)
-
 	// Only process if we have user mentions (ignore channel mentions for now)
 	if len(mentions.UserMentions) == 0 {
-		p.API.LogDebug("No user mentions found, skipping mention processing", "post_id", post.Id)
 		return
 	}
 
@@ -655,7 +648,6 @@ func (p *Plugin) addMatrixMentionsWithData(content map[string]any, post *model.P
 	var mentionReplacements []struct {
 		username    string
 		ghostUserID string
-		displayName string
 	}
 
 	// First pass: collect all mention data
@@ -667,44 +659,22 @@ func (p *Plugin) addMatrixMentionsWithData(content map[string]any, post *model.P
 			continue
 		}
 
-		var matrixUserID string
-		var displayName string
-
-		// Check if this user has a Matrix ghost user (Mattermost user → Matrix ghost)
+		// Check if this user has a Matrix ghost user
 		if ghostUserID, exists := p.getGhostUser(user.Id); exists {
-			matrixUserID = ghostUserID
-			displayName = user.GetDisplayName(model.ShowFullName)
-			if displayName == "" {
-				displayName = user.Username // Fallback to username
-			}
-			p.API.LogDebug("Found Matrix ghost user for Mattermost user mention", "username", username, "ghost_user_id", ghostUserID, "display_name", displayName)
-		} else {
-			// Check if this is a Matrix user represented in Mattermost (Matrix user → Mattermost user)
-			originalMatrixUserID := p.getOriginalMatrixUserID(user.Id)
-			if originalMatrixUserID != "" {
-				matrixUserID = originalMatrixUserID
-				displayName = user.GetDisplayName(model.ShowFullName)
-				if displayName == "" {
-					displayName = user.Username // Fallback to username
-				}
-				p.API.LogDebug("Found original Matrix user for bridged user mention", "username", username, "original_matrix_user_id", originalMatrixUserID, "display_name", displayName)
-			} else {
-				p.API.LogDebug("No Matrix representation found for mention", "username", username, "user_id", user.Id)
-				continue
-			}
-		}
+			matrixUserIDs = append(matrixUserIDs, ghostUserID)
+			mentionReplacements = append(mentionReplacements, struct {
+				username    string
+				ghostUserID string
+			}{username, ghostUserID})
 
-		matrixUserIDs = append(matrixUserIDs, matrixUserID)
-		mentionReplacements = append(mentionReplacements, struct {
-			username    string
-			ghostUserID string
-			displayName string
-		}{username, matrixUserID, displayName})
+			p.API.LogDebug("Converted Mattermost mention to Matrix", "username", username, "ghost_user_id", ghostUserID)
+		} else {
+			p.API.LogDebug("No Matrix ghost user found for mention", "username", username, "user_id", user.Id)
+		}
 	}
 
 	// Only proceed if we have Matrix users to mention
 	if len(matrixUserIDs) == 0 {
-		p.API.LogDebug("No Matrix ghost users found for any mentions, skipping mention processing", "post_id", post.Id, "attempted_usernames", mentions.UserMentions)
 		return
 	}
 
@@ -721,55 +691,22 @@ func (p *Plugin) addMatrixMentionsWithData(content map[string]any, post *model.P
 
 	// Second pass: replace mentions in HTML content
 	for _, replacement := range mentionReplacements {
-		// Replace @username with proper Matrix mention pill format
+		// Replace @username with Matrix mention link in HTML
 		// Use more robust replacement that handles HTML escaping
 		usernamePattern := fmt.Sprintf(`@%s\b`, regexp.QuoteMeta(replacement.username))
 		usernameRegex := regexp.MustCompile(usernamePattern)
-
-		// Create Matrix mention pill format to match native Matrix mentions
-		matrixMentionPill := fmt.Sprintf(`<a href="https://matrix.to/#/%s">%s</a>`,
-			replacement.ghostUserID, replacement.displayName)
-		updatedHTML = usernameRegex.ReplaceAllString(updatedHTML, matrixMentionPill)
+		matrixMentionLink := fmt.Sprintf(`<a href="https://matrix.to/#/%s">@%s</a>`, replacement.ghostUserID, replacement.username)
+		updatedHTML = usernameRegex.ReplaceAllString(updatedHTML, matrixMentionLink)
 	}
 
 	// Add Matrix mentions structure
-	mentionsField := map[string]any{
+	content["m.mentions"] = map[string]any{
 		"user_ids": matrixUserIDs,
 	}
-	content["m.mentions"] = mentionsField
 	content["formatted_body"] = updatedHTML
 	content["format"] = "org.matrix.custom.html"
 
-	p.API.LogDebug("Added Matrix mentions to message", "post_id", post.Id, "mentioned_users", len(matrixUserIDs), "matrix_user_ids", matrixUserIDs, "m_mentions", mentionsField)
-}
-
-// getOriginalMatrixUserID looks up the original Matrix user ID for a Mattermost user created from Matrix
-func (p *Plugin) getOriginalMatrixUserID(mattermostUserID string) string {
-	// Search through all matrix_user_* mappings to find one that points to this Mattermost user
-	keys, err := p.kvstore.ListKeys(0, 1000)
-	if err != nil {
-		p.API.LogWarn("Failed to list kvstore keys for Matrix user lookup", "error", err, "mattermost_user_id", mattermostUserID)
-		return ""
-	}
-
-	matrixUserPrefix := "matrix_user_"
-	for _, key := range keys {
-		if strings.HasPrefix(key, matrixUserPrefix) {
-			userIDBytes, err := p.kvstore.Get(key)
-			if err != nil {
-				continue
-			}
-
-			if string(userIDBytes) == mattermostUserID {
-				// Found the mapping - extract Matrix user ID from the key
-				matrixUserID := strings.TrimPrefix(key, matrixUserPrefix)
-				p.API.LogDebug("Found original Matrix user ID", "mattermost_user_id", mattermostUserID, "matrix_user_id", matrixUserID)
-				return matrixUserID
-			}
-		}
-	}
-
-	return ""
+	p.API.LogDebug("Added Matrix mentions to message", "post_id", post.Id, "mentioned_users", len(matrixUserIDs), "matrix_user_ids", matrixUserIDs)
 }
 
 // isMatrixContentIdentical compares current Matrix event content with new content to detect if update is needed

--- a/server/sync_to_mattermost.go
+++ b/server/sync_to_mattermost.go
@@ -1024,85 +1024,42 @@ func (p *Plugin) syncMatrixMemberEventToMattermost(event MatrixEvent, channelID 
 		return nil
 	}
 
-	// Check if we have a Mattermost user for this Matrix user
-	userMapKey := "matrix_user_" + event.Sender
-	userIDBytes, err := p.kvstore.Get(userMapKey)
-	existingUserID := ""
-	userExists := false
-	if err == nil && len(userIDBytes) > 0 {
-		existingUserID = string(userIDBytes)
-		userExists = true
-	}
-
-	switch membership {
-	case "join":
-		return p.handleMatrixMemberJoin(event, channelID, existingUserID, userExists)
-	case "leave", "ban":
-		return p.handleMatrixMemberLeave(event, channelID, existingUserID, userExists)
-	default:
-		p.API.LogDebug("Ignoring unsupported membership state", "event_id", event.EventID, "sender", event.Sender, "membership", membership)
+	// We only care about profile changes for existing members
+	// Profile changes happen when membership is "join" and there are profile fields
+	if membership != "join" {
+		p.API.LogDebug("Ignoring non-join member event", "event_id", event.EventID, "sender", event.Sender, "membership", membership)
 		return nil
 	}
-}
 
-// handleMatrixMemberJoin processes Matrix member join events - both new joins and profile changes
-func (p *Plugin) handleMatrixMemberJoin(event MatrixEvent, channelID, existingUserID string, userExists bool) error {
 	// Check if this is a profile change (has displayname or avatar_url in content)
 	displayName, hasDisplayName := event.Content["displayname"].(string)
 	avatarURL, hasAvatarURL := event.Content["avatar_url"].(string)
-	hasProfileData := hasDisplayName || hasAvatarURL
 
-	if userExists {
-		// Existing user joining - always ensure they're in the channel first
-		p.API.LogDebug("Ensuring existing Matrix user is in Mattermost channel", "event_id", event.EventID, "sender", event.Sender, "channel_id", channelID)
-		if err := p.ensureUserInChannel(existingUserID, channelID); err != nil {
-			p.API.LogWarn("Failed to ensure existing user is in channel", "error", err, "user_id", existingUserID, "channel_id", channelID)
-		}
-
-		// Also handle profile change if profile data is present
-		if hasProfileData {
-			p.API.LogDebug("Detected Matrix profile change for existing user", "event_id", event.EventID, "sender", event.Sender, "display_name", displayName, "avatar_url", avatarURL)
-			return p.updateExistingUserProfile(existingUserID, event.Sender, event.EventID, displayName, avatarURL)
-		}
-
+	if !hasDisplayName && !hasAvatarURL {
+		p.API.LogDebug("Member event has no profile information", "event_id", event.EventID, "sender", event.Sender)
 		return nil
 	}
 
-	// New user joining - create them and add to channel
-	p.API.LogDebug("New Matrix user joining room", "event_id", event.EventID, "sender", event.Sender, "channel_id", channelID)
-	mattermostUserID, err := p.getOrCreateMattermostUser(event.Sender, channelID)
-	if err != nil {
-		return errors.Wrap(err, "failed to create Mattermost user for Matrix join")
+	p.API.LogDebug("Detected Matrix profile change", "event_id", event.EventID, "sender", event.Sender, "display_name", displayName, "avatar_url", avatarURL)
+
+	// Check if we have a Mattermost user for this Matrix user
+	userMapKey := "matrix_user_" + event.Sender
+	userIDBytes, err := p.kvstore.Get(userMapKey)
+	if err != nil || len(userIDBytes) == 0 {
+		p.API.LogDebug("No Mattermost user found for Matrix user profile change", "matrix_user_id", event.Sender, "event_id", event.EventID)
+		return nil // User doesn't exist in Mattermost yet, ignore profile change
 	}
 
-	// Add the new user to the channel
-	return p.addUserToChannel(mattermostUserID, channelID)
-}
+	mattermostUserID := string(userIDBytes)
 
-// handleMatrixMemberLeave processes Matrix member leave/ban events
-func (p *Plugin) handleMatrixMemberLeave(event MatrixEvent, channelID, existingUserID string, userExists bool) error {
-	if !userExists {
-		p.API.LogDebug("Matrix user leaving room but no Mattermost user exists", "event_id", event.EventID, "sender", event.Sender)
-		return nil
-	}
-
-	membership := event.Content["membership"].(string)
-	p.API.LogDebug("Matrix user leaving room", "event_id", event.EventID, "sender", event.Sender, "membership", membership, "channel_id", channelID)
-
-	// Remove user from the Mattermost channel
-	return p.removeUserFromChannel(existingUserID, channelID)
-}
-
-// updateExistingUserProfile updates an existing user's profile from Matrix event data
-func (p *Plugin) updateExistingUserProfile(mattermostUserID, matrixUserID, eventID, displayName, avatarURL string) error {
 	// Get the existing Mattermost user
 	mattermostUser, appErr := p.API.GetUser(mattermostUserID)
 	if appErr != nil {
-		p.API.LogWarn("Failed to get Mattermost user for profile update", "error", appErr, "user_id", mattermostUserID, "matrix_user_id", matrixUserID)
+		p.API.LogWarn("Failed to get Mattermost user for profile update", "error", appErr, "user_id", mattermostUserID, "matrix_user_id", event.Sender)
 		return nil
 	}
 
-	p.API.LogDebug("Found Mattermost user for profile update", "user_id", mattermostUser.Id, "username", mattermostUser.Username, "matrix_user_id", matrixUserID)
+	p.API.LogDebug("Found Mattermost user for profile update", "user_id", mattermostUser.Id, "username", mattermostUser.Username, "matrix_user_id", event.Sender)
 
 	// Create profile data from Matrix event
 	eventProfile := &matrix.UserProfile{
@@ -1112,53 +1069,11 @@ func (p *Plugin) updateExistingUserProfile(mattermostUserID, matrixUserID, event
 
 	// Update the user's profile using the unified method
 	context := &ProfileUpdateContext{
-		EventID: eventID,
+		EventID: event.EventID,
 		Source:  "event",
 	}
 
-	p.updateMattermostUserProfile(mattermostUser, matrixUserID, context, eventProfile)
-	return nil
-}
+	p.updateMattermostUserProfile(mattermostUser, event.Sender, context, eventProfile)
 
-// ensureUserInChannel ensures a user is a member of the specified channel
-func (p *Plugin) ensureUserInChannel(userID, channelID string) error {
-	// Check if user is already a channel member
-	_, appErr := p.API.GetChannelMember(channelID, userID)
-	if appErr == nil {
-		// User is already a channel member
-		p.API.LogDebug("User already member of channel", "user_id", userID, "channel_id", channelID)
-		return nil
-	}
-
-	// Add user to the channel
-	return p.addUserToChannel(userID, channelID)
-}
-
-// addUserToChannel adds a user to a Mattermost channel
-func (p *Plugin) addUserToChannel(userID, channelID string) error {
-	// Ensure user is in the team first
-	if err := p.addUserToChannelTeam(userID, channelID); err != nil {
-		return errors.Wrap(err, "failed to add user to team")
-	}
-
-	// Add user to the channel
-	_, appErr := p.API.AddChannelMember(channelID, userID)
-	if appErr != nil {
-		return errors.Wrap(appErr, "failed to add user to channel")
-	}
-
-	p.API.LogDebug("Added Matrix user to Mattermost channel", "user_id", userID, "channel_id", channelID)
-	return nil
-}
-
-// removeUserFromChannel removes a user from a Mattermost channel
-func (p *Plugin) removeUserFromChannel(userID, channelID string) error {
-	// Remove user from the channel
-	appErr := p.API.DeleteChannelMember(channelID, userID)
-	if appErr != nil {
-		return errors.Wrap(appErr, "failed to remove user from channel")
-	}
-
-	p.API.LogDebug("Removed Matrix user from Mattermost channel", "user_id", userID, "channel_id", channelID)
 	return nil
 }

--- a/server/sync_to_mattermost.go
+++ b/server/sync_to_mattermost.go
@@ -74,27 +74,11 @@ func (p *Plugin) syncMatrixMessageToMattermost(event MatrixEvent, channelID stri
 	// Check if this is a threaded message (reply)
 	var rootID string
 	if relatesTo, exists := event.Content["m.relates_to"].(map[string]any); exists {
-		// Check for Matrix reply structure (m.in_reply_to)
-		if inReplyTo, hasInReplyTo := relatesTo["m.in_reply_to"].(map[string]any); hasInReplyTo {
-			if parentEventID, hasEventID := inReplyTo["event_id"].(string); hasEventID {
+		if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.thread" {
+			if parentEventID, exists := relatesTo["event_id"].(string); exists {
 				// Find the Mattermost post ID for this Matrix event
 				if mattermostPostID := p.getPostIDFromMatrixEvent(parentEventID, channelID); mattermostPostID != "" {
 					rootID = mattermostPostID
-					p.API.LogDebug("Found Matrix reply, setting root ID", "matrix_event_id", event.EventID, "parent_event_id", parentEventID, "mattermost_root_id", rootID)
-				} else {
-					p.API.LogDebug("Matrix reply parent not found in Mattermost", "matrix_event_id", event.EventID, "parent_event_id", parentEventID)
-				}
-			}
-		}
-		// Also check for thread relation (m.thread) as fallback
-		if rootID == "" {
-			if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.thread" {
-				if parentEventID, exists := relatesTo["event_id"].(string); exists {
-					// Find the Mattermost post ID for this Matrix event
-					if mattermostPostID := p.getPostIDFromMatrixEvent(parentEventID, channelID); mattermostPostID != "" {
-						rootID = mattermostPostID
-						p.API.LogDebug("Found Matrix thread, setting root ID", "matrix_event_id", event.EventID, "parent_event_id", parentEventID, "mattermost_root_id", rootID)
-					}
 				}
 			}
 		}
@@ -187,6 +171,18 @@ func (p *Plugin) syncMatrixFileToMattermost(event MatrixEvent, channelID string)
 		return nil
 	}
 
+	// Extract file info if available
+	var fileSize int64
+	var mimeType string
+	if info, hasInfo := event.Content["info"].(map[string]any); hasInfo {
+		if size, hasSize := info["size"].(float64); hasSize {
+			fileSize = int64(size)
+		}
+		if mime, hasMime := info["mimetype"].(string); hasMime {
+			mimeType = mime
+		}
+	}
+
 	// Get or create Mattermost user for the Matrix sender
 	mattermostUserID, err := p.getOrCreateMattermostUser(event.Sender, channelID)
 	if err != nil {
@@ -199,6 +195,19 @@ func (p *Plugin) syncMatrixFileToMattermost(event MatrixEvent, channelID string)
 		return errors.Wrap(err, "failed to download Matrix file")
 	}
 
+	// Create file info for Mattermost
+	fileInfo := &model.FileInfo{
+		Name:     body,
+		Size:     fileSize,
+		MimeType: mimeType,
+		Content:  string(fileData),
+	}
+
+	// If no mime type was provided, try to detect it
+	if fileInfo.MimeType == "" {
+		fileInfo.MimeType = p.detectMimeType(body, fileData)
+	}
+
 	// Upload file to Mattermost
 	uploadedFileInfo, appErr := p.API.UploadFile(fileData, channelID, body)
 	if appErr != nil {
@@ -208,27 +217,11 @@ func (p *Plugin) syncMatrixFileToMattermost(event MatrixEvent, channelID string)
 	// Check if this is a threaded message (reply)
 	var rootID string
 	if relatesTo, exists := event.Content["m.relates_to"].(map[string]any); exists {
-		// Check for Matrix reply structure (m.in_reply_to)
-		if inReplyTo, hasInReplyTo := relatesTo["m.in_reply_to"].(map[string]any); hasInReplyTo {
-			if parentEventID, hasEventID := inReplyTo["event_id"].(string); hasEventID {
+		if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.thread" {
+			if parentEventID, exists := relatesTo["event_id"].(string); exists {
 				// Find the Mattermost post ID for this Matrix event
 				if mattermostPostID := p.getPostIDFromMatrixEvent(parentEventID, channelID); mattermostPostID != "" {
 					rootID = mattermostPostID
-					p.API.LogDebug("Found Matrix file reply, setting root ID", "matrix_event_id", event.EventID, "parent_event_id", parentEventID, "mattermost_root_id", rootID)
-				} else {
-					p.API.LogDebug("Matrix file reply parent not found in Mattermost", "matrix_event_id", event.EventID, "parent_event_id", parentEventID)
-				}
-			}
-		}
-		// Also check for thread relation (m.thread) as fallback
-		if rootID == "" {
-			if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.thread" {
-				if parentEventID, exists := relatesTo["event_id"].(string); exists {
-					// Find the Mattermost post ID for this Matrix event
-					if mattermostPostID := p.getPostIDFromMatrixEvent(parentEventID, channelID); mattermostPostID != "" {
-						rootID = mattermostPostID
-						p.API.LogDebug("Found Matrix file thread, setting root ID", "matrix_event_id", event.EventID, "parent_event_id", parentEventID, "mattermost_root_id", rootID)
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
This PR reverts the 4 commits from PR #1, which will allow https://github.com/mattermost/mattermost-plugin-matrix-bridge/pull/3 to merge cleanly.  The PR https://github.com/mattermost/mattermost-plugin-matrix-bridge/pull/3 already contains modified versions of the fixes being reverted here.

**Reverted commits:**
- `0713e16` - Fix pill-box display in Matrix for mentions  
- `45965e9` - Modified handleMatrixMemberJoin() to always ensure existing users are added to channels
- `fcdcf0d` - fix reply-to Matrix
- `7a88ef4` - fix image upload from Matrix

 