### PR TITLE
Fix room creation and mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ detach: setup-attach
 .PHONY: test
 test: apply webapp/node_modules install-go-tools
 ifneq ($(HAS_SERVER),)
-	$(GOBIN)/gotestsum -- -v ./...
+	$(GOBIN)/gotestsum -- -v -count=1 -p 1 ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run test;
@@ -330,7 +330,7 @@ endif
 .PHONY: test-ci
 test-ci: apply webapp/node_modules install-go-tools
 ifneq ($(HAS_SERVER),)
-	$(GOBIN)/gotestsum --format standard-verbose --junitfile report.xml -- ./...
+	$(GOBIN)/gotestsum --format standard-verbose --junitfile report.xml -- -p 1 ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run test;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/wiggin77/mattermost-plugin-matrix-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/wiggin77/mattermost-plugin-matrix-bridge/actions/workflows/ci.yml)
 
-A seamless bridge that connects Mattermost and Matrix, enabling real-time bidirectional message synchronization between platforms.
+A bidirectional bridge that connects Mattermost and Matrix, enabling real-time message synchronization between platforms.
 
 ## Features
 

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -85,54 +85,6 @@ func setupTest() *env {
 	}
 }
 
-func TestHelloCommand(t *testing.T) {
-	assert := assert.New(t)
-	env := setupTest()
-
-	// Expect both command registrations
-	env.api.On("RegisterCommand", &model.Command{
-		Trigger:          helloCommandTrigger,
-		AutoComplete:     true,
-		AutoCompleteDesc: "Say hello to someone",
-		AutoCompleteHint: "[@username]",
-		AutocompleteData: model.NewAutocompleteData("hello", "[@username]", "Username to say hello to"),
-	}).Return(nil)
-
-	matrixData := model.NewAutocompleteData(matrixCommandTrigger, "[subcommand]", "Matrix bridge commands")
-	matrixData.AddCommand(model.NewAutocompleteData("test", "", "Test Matrix server connection and configuration"))
-	matrixData.AddCommand(model.NewAutocompleteData("create", "[room_name] [publish=true|false]", "Create a new Matrix room and map to current channel (uses channel name if room name not provided)"))
-	matrixData.AddCommand(model.NewAutocompleteData("map", "[room_alias|room_id]", "Map current channel to Matrix room (prefer #alias:server.com)"))
-	matrixData.AddCommand(model.NewAutocompleteData("list", "", "List all channel-to-room mappings"))
-	matrixData.AddCommand(model.NewAutocompleteData("status", "", "Show bridge status"))
-	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", "Reset and re-run KV store migrations to fix missing room mappings"))
-
-	env.api.On("RegisterCommand", &model.Command{
-		Trigger:          matrixCommandTrigger,
-		AutoComplete:     true,
-		AutoCompleteDesc: "Matrix bridge commands",
-		AutoCompleteHint: "[subcommand]",
-		AutocompleteData: matrixData,
-	}).Return(nil)
-
-	// Create mock plugin API
-	mockPlugin := &mockPlugin{
-		client:       env.client,
-		kvstore:      kvstore.NewKVStore(env.client),
-		matrixClient: matrix.NewClient("http://test.com", "test_token", "test_remote_id", env.api),
-		config:       &mockConfiguration{serverURL: "http://test.com"},
-		pluginAPI:    env.api,
-	}
-
-	cmdHandler := NewCommandHandler(mockPlugin)
-
-	args := &model.CommandArgs{
-		Command: "/hello world",
-	}
-	response, err := cmdHandler.Handle(args)
-	assert.Nil(err)
-	assert.Equal("Hello, world", response.Text)
-}
-
 func TestMatrixCreateCommandParsing(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -378,23 +330,24 @@ func (t *testCommandHandler) Handle(args *model.CommandArgs) (*model.CommandResp
 }
 
 func setupCommandRegistration(env *env) {
-	// Hello command registration
-	env.api.On("RegisterCommand", &model.Command{
-		Trigger:          helloCommandTrigger,
-		AutoComplete:     true,
-		AutoCompleteDesc: "Say hello to someone",
-		AutoCompleteHint: "[@username]",
-		AutocompleteData: model.NewAutocompleteData("hello", "[@username]", "Username to say hello to"),
-	}).Return(nil)
-
 	// Matrix command registration
 	matrixData := model.NewAutocompleteData(matrixCommandTrigger, "[subcommand]", "Matrix bridge commands")
-	matrixData.AddCommand(model.NewAutocompleteData("test", "", "Test Matrix server connection and configuration"))
-	matrixData.AddCommand(model.NewAutocompleteData("create", "[room_name] [publish=true|false]", "Create a new Matrix room and map to current channel (uses channel name if room name not provided)"))
-	matrixData.AddCommand(model.NewAutocompleteData("map", "[room_alias|room_id]", "Map current channel to Matrix room (prefer #alias:server.com)"))
-	matrixData.AddCommand(model.NewAutocompleteData("list", "", "List all channel-to-room mappings"))
-	matrixData.AddCommand(model.NewAutocompleteData("status", "", "Show bridge status"))
-	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", "Reset and re-run KV store migrations to fix missing room mappings"))
+	matrixData.AddCommand(model.NewAutocompleteData("test", "", testCommandDesc))
+
+	// Create command with argument completion
+	createCmd := model.NewAutocompleteData("create", createCommandHint, createCommandDesc)
+	createCmd.AddTextArgument("Optional room name (defaults to channel name)", "[room_name]", "")
+	createCmd.AddTextArgument("Optional publish flag", "[publish=true|false]", "")
+	matrixData.AddCommand(createCmd)
+
+	// Map command with argument completion
+	mapCmd := model.NewAutocompleteData("map", mapCommandHint, mapCommandDesc)
+	mapCmd.AddTextArgument("Matrix room alias or room ID", "[room_alias|room_id]", "")
+	matrixData.AddCommand(mapCmd)
+
+	matrixData.AddCommand(model.NewAutocompleteData("list", "", listCommandDesc))
+	matrixData.AddCommand(model.NewAutocompleteData("status", "", statusCommandDesc))
+	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", migrateCommandDesc))
 
 	env.api.On("RegisterCommand", &model.Command{
 		Trigger:          matrixCommandTrigger,
@@ -509,10 +462,10 @@ func TestMatrixCommandErrors(t *testing.T) {
 			description: "should handle missing subcommand",
 		},
 		{
-			name:        "completely different command",
-			command:     "/hello",
+			name:        "unknown command",
+			command:     "/unknown",
 			expectError: false,
-			description: "should handle hello command normally",
+			description: "should handle unknown commands gracefully",
 		},
 	}
 

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -64,6 +64,16 @@ func (m *mockPlugin) RunKVStoreMigrations() error {
 	return nil // Mock implementation always succeeds
 }
 
+func (m *mockPlugin) RunKVStoreMigrationsWithResults() (*MigrationResult, error) {
+	return &MigrationResult{
+		UserMappingsCreated:      5,
+		ChannelMappingsCreated:   3,
+		RoomMappingsCreated:      2,
+		DMMappingsCreated:        1,
+		ReverseDMMappingsCreated: 1,
+	}, nil // Mock implementation returns sample results
+}
+
 func setupTest() *env {
 	api := &plugintest.API{}
 	driver := &plugintest.Driver{}

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -60,6 +60,10 @@ func (m *mockPlugin) GetPluginAPIClient() *pluginapi.Client {
 	return m.client
 }
 
+func (m *mockPlugin) RunKVStoreMigrations() error {
+	return nil // Mock implementation always succeeds
+}
+
 func setupTest() *env {
 	api := &plugintest.API{}
 	driver := &plugintest.Driver{}
@@ -90,6 +94,7 @@ func TestHelloCommand(t *testing.T) {
 	matrixData.AddCommand(model.NewAutocompleteData("map", "[room_alias|room_id]", "Map current channel to Matrix room (prefer #alias:server.com)"))
 	matrixData.AddCommand(model.NewAutocompleteData("list", "", "List all channel-to-room mappings"))
 	matrixData.AddCommand(model.NewAutocompleteData("status", "", "Show bridge status"))
+	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", "Reset and re-run KV store migrations to fix missing room mappings"))
 
 	env.api.On("RegisterCommand", &model.Command{
 		Trigger:          matrixCommandTrigger,
@@ -379,6 +384,7 @@ func setupCommandRegistration(env *env) {
 	matrixData.AddCommand(model.NewAutocompleteData("map", "[room_alias|room_id]", "Map current channel to Matrix room (prefer #alias:server.com)"))
 	matrixData.AddCommand(model.NewAutocompleteData("list", "", "List all channel-to-room mappings"))
 	matrixData.AddCommand(model.NewAutocompleteData("status", "", "Show bridge status"))
+	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", "Reset and re-run KV store migrations to fix missing room mappings"))
 
 	env.api.On("RegisterCommand", &model.Command{
 		Trigger:          matrixCommandTrigger,

--- a/server/command/mocks/mock_commands.go
+++ b/server/command/mocks/mock_commands.go
@@ -44,7 +44,7 @@ func (m *MockCommand) Handle(arg0 *model.CommandArgs) (*model.CommandResponse, e
 }
 
 // Handle indicates an expected call of Handle.
-func (mr *MockCommandMockRecorder) Handle(arg0 any) *gomock.Call {
+func (mr *MockCommandMockRecorder) Handle(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockCommand)(nil).Handle), arg0)
 }
@@ -58,7 +58,7 @@ func (m *MockCommand) executeHelloCommand(arg0 *model.CommandArgs) *model.Comman
 }
 
 // executeHelloCommand indicates an expected call of executeHelloCommand.
-func (mr *MockCommandMockRecorder) executeHelloCommand(arg0 any) *gomock.Call {
+func (mr *MockCommandMockRecorder) executeHelloCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "executeHelloCommand", reflect.TypeOf((*MockCommand)(nil).executeHelloCommand), arg0)
 }
@@ -72,7 +72,7 @@ func (m *MockCommand) executeMatrixCommand(arg0 *model.CommandArgs) *model.Comma
 }
 
 // executeMatrixCommand indicates an expected call of executeMatrixCommand.
-func (mr *MockCommandMockRecorder) executeMatrixCommand(arg0 any) *gomock.Call {
+func (mr *MockCommandMockRecorder) executeMatrixCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "executeMatrixCommand", reflect.TypeOf((*MockCommand)(nil).executeMatrixCommand), arg0)
 }

--- a/server/command/mocks/mock_commands.go
+++ b/server/command/mocks/mock_commands.go
@@ -49,20 +49,6 @@ func (mr *MockCommandMockRecorder) Handle(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockCommand)(nil).Handle), arg0)
 }
 
-// executeHelloCommand mocks base method.
-func (m *MockCommand) executeHelloCommand(arg0 *model.CommandArgs) *model.CommandResponse {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "executeHelloCommand", arg0)
-	ret0, _ := ret[0].(*model.CommandResponse)
-	return ret0
-}
-
-// executeHelloCommand indicates an expected call of executeHelloCommand.
-func (mr *MockCommandMockRecorder) executeHelloCommand(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "executeHelloCommand", reflect.TypeOf((*MockCommand)(nil).executeHelloCommand), arg0)
-}
-
 // executeMatrixCommand mocks base method.
 func (m *MockCommand) executeMatrixCommand(arg0 *model.CommandArgs) *model.CommandResponse {
 	m.ctrl.T.Helper()

--- a/server/matrix/client_test.go
+++ b/server/matrix/client_test.go
@@ -11,7 +11,7 @@ import (
 	matrixtest "github.com/wiggin77/mattermost-plugin-matrix-bridge/testcontainers/matrix"
 )
 
-// MatrixClientTestSuite contains integration tests for Matrix client operations
+// MatrixClientTestSuite contains integration tests for Matrix client operations.
 type MatrixClientTestSuite struct {
 	suite.Suite
 	matrixContainer *matrixtest.MatrixContainer
@@ -48,7 +48,6 @@ func (suite *MatrixClientTestSuite) SetupTest() {
 // TestMatrixClientOperations tests core Matrix client operations that affect change
 // and then query the server to verify the changes were applied correctly.
 func (suite *MatrixClientTestSuite) TestMatrixClientOperations() {
-
 	// Test server connectivity first
 	suite.Run("TestConnection", func() {
 		err := suite.client.TestConnection()

--- a/server/matrix/client_test.go
+++ b/server/matrix/client_test.go
@@ -1,0 +1,692 @@
+package matrix
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	matrixtest "github.com/wiggin77/mattermost-plugin-matrix-bridge/testcontainers/matrix"
+)
+
+// TestMatrixClientOperations tests core Matrix client operations that affect change
+// and then query the server to verify the changes were applied correctly.
+// This approach validates compatibility across different Matrix server implementations.
+func TestMatrixClientOperations(t *testing.T) {
+	// Start Matrix test container
+	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
+	defer matrixContainer.Cleanup(t)
+
+	// Create Matrix client
+	client := NewClientWithLogger(
+		matrixContainer.ServerURL,
+		matrixContainer.ASToken,
+		"test-remote-id",
+		NewTestLogger(t),
+	)
+	client.SetServerDomain(matrixContainer.ServerDomain)
+
+	// Test server connectivity first
+	t.Run("TestConnection", func(t *testing.T) {
+		err := client.TestConnection()
+		require.NoError(t, err, "Should connect to Matrix server")
+	})
+
+	// Test Application Service permissions
+	t.Run("TestApplicationServicePermissions", func(t *testing.T) {
+		err := client.TestApplicationServicePermissions()
+		require.NoError(t, err, "Should have proper AS permissions")
+	})
+
+	// Test server information retrieval
+	t.Run("GetServerInfo", func(t *testing.T) {
+		serverInfo, err := client.GetServerInfo()
+		require.NoError(t, err, "Should retrieve server info")
+		assert.NotEmpty(t, serverInfo.Name, "Server name should not be empty")
+		t.Logf("Server: %s %s", serverInfo.Name, serverInfo.Version)
+	})
+
+	// Run room operation tests
+	t.Run("RoomOperations", func(t *testing.T) {
+		testRoomOperations(t, client, matrixContainer.ServerDomain)
+	})
+
+	// Run user operation tests
+	t.Run("UserOperations", func(t *testing.T) {
+		testUserOperations(t, client)
+	})
+
+	// Run message operation tests
+	t.Run("MessageOperations", func(t *testing.T) {
+		testMessageOperations(t, client, matrixContainer.ServerDomain)
+	})
+
+	// Run media operation tests
+	t.Run("MediaOperations", func(t *testing.T) {
+		testMediaOperations(t, client)
+	})
+}
+
+// testRoomOperations tests room creation, joining, and management operations
+func testRoomOperations(t *testing.T, client *Client, serverDomain string) {
+	t.Run("CreateRoom", func(t *testing.T) {
+		// Create a room and verify it exists
+		roomName := "Test Room"
+		roomTopic := "Integration test room"
+		mattermostChannelID := "test-channel-123"
+
+		roomIdentifier, err := client.CreateRoom(roomName, roomTopic, serverDomain, true, mattermostChannelID)
+		require.NoError(t, err, "Should create room successfully")
+		assert.NotEmpty(t, roomIdentifier, "Room identifier should not be empty")
+		t.Logf("Created room: %s", roomIdentifier)
+
+		// Verify room was created by resolving the identifier
+		roomID, err := client.ResolveRoomAlias(roomIdentifier)
+		require.NoError(t, err, "Should resolve room identifier")
+		assert.NotEmpty(t, roomID, "Room ID should not be empty")
+		assert.True(t, strings.HasPrefix(roomID, "!"), "Room ID should start with !")
+
+		// Verify Mattermost channel ID was stored in room state
+		retrievedChannelID, err := client.GetMattermostChannelID(roomID)
+		require.NoError(t, err, "Should retrieve Mattermost channel ID")
+		assert.Equal(t, mattermostChannelID, retrievedChannelID, "Channel ID should match")
+	})
+
+	t.Run("CreateDirectRoom", func(t *testing.T) {
+		// Create ghost users for DM
+		ghostUser1 := "@_mattermost_user1:" + serverDomain
+		ghostUser2 := "@_mattermost_user2:" + serverDomain
+		ghostUserIDs := []string{ghostUser1, ghostUser2}
+
+		roomID, err := client.CreateDirectRoom(ghostUserIDs, "Test DM")
+		require.NoError(t, err, "Should create direct room")
+		assert.NotEmpty(t, roomID, "Room ID should not be empty")
+		assert.True(t, strings.HasPrefix(roomID, "!"), "Room ID should start with !")
+		t.Logf("Created DM room: %s", roomID)
+	})
+
+	t.Run("JoinRoom", func(t *testing.T) {
+		// Create a room first
+		roomIdentifier, err := client.CreateRoom("Join Test Room", "Test joining", serverDomain, false, "test-join-channel")
+		require.NoError(t, err, "Should create room for join test")
+
+		// Join the room (AS should already be in room, but test the API)
+		err = client.JoinRoom(roomIdentifier)
+		require.NoError(t, err, "Should join room successfully")
+	})
+
+	t.Run("AddRoomAlias", func(t *testing.T) {
+		// Create a room
+		roomIdentifier, err := client.CreateRoom("Alias Test Room", "Test aliases", serverDomain, false, "test-alias-channel")
+		require.NoError(t, err, "Should create room for alias test")
+
+		roomID, err := client.ResolveRoomAlias(roomIdentifier)
+		require.NoError(t, err, "Should resolve room identifier")
+
+		// Add an additional alias within the reserved namespace
+		additionalAlias := "#_mattermost_additional-alias-test:" + serverDomain
+		err = client.AddRoomAlias(roomID, additionalAlias)
+		require.NoError(t, err, "Should add room alias")
+
+		// Verify the alias resolves to the same room
+		resolvedRoomID, err := client.ResolveRoomAlias(additionalAlias)
+		require.NoError(t, err, "Should resolve additional alias")
+		assert.Equal(t, roomID, resolvedRoomID, "Additional alias should resolve to same room")
+	})
+}
+
+// testUserOperations tests user creation and profile management operations
+func testUserOperations(t *testing.T, client *Client) {
+	t.Run("CreateGhostUser", func(t *testing.T) {
+		mattermostUserID := "test-user-123"
+		displayName := "Test User"
+		avatarData := []byte("fake-avatar-data")
+		avatarContentType := "image/png"
+
+		ghostUser, err := client.CreateGhostUser(mattermostUserID, displayName, avatarData, avatarContentType)
+		require.NoError(t, err, "Should create ghost user")
+		assert.NotNil(t, ghostUser, "Ghost user should not be nil")
+		assert.NotEmpty(t, ghostUser.UserID, "Ghost user ID should not be empty")
+		assert.Contains(t, ghostUser.UserID, mattermostUserID, "Ghost user ID should contain Mattermost user ID")
+		t.Logf("Created ghost user: %s", ghostUser.UserID)
+
+		// Verify user profile was set correctly
+		profile, err := client.GetUserProfile(ghostUser.UserID)
+		require.NoError(t, err, "Should get user profile")
+		assert.Equal(t, displayName, profile.DisplayName, "Display name should match")
+		assert.NotEmpty(t, profile.AvatarURL, "Avatar URL should be set")
+	})
+
+	t.Run("UpdateUserProfile", func(t *testing.T) {
+		// Create a ghost user first
+		mattermostUserID := "test-user-456"
+		ghostUser, err := client.CreateGhostUser(mattermostUserID, "Original Name", nil, "")
+		require.NoError(t, err, "Should create ghost user for profile test")
+
+		// Update display name
+		newDisplayName := "Updated Display Name"
+		err = client.SetDisplayName(ghostUser.UserID, newDisplayName)
+		require.NoError(t, err, "Should update display name")
+
+		// Verify the change
+		profile, err := client.GetUserProfile(ghostUser.UserID)
+		require.NoError(t, err, "Should get updated profile")
+		assert.Equal(t, newDisplayName, profile.DisplayName, "Display name should be updated")
+
+		// Update avatar
+		newAvatarData := []byte("new-fake-avatar-data")
+		err = client.UpdateGhostUserAvatar(ghostUser.UserID, newAvatarData, "image/jpeg")
+		require.NoError(t, err, "Should update avatar")
+
+		// Verify avatar was updated
+		updatedProfile, err := client.GetUserProfile(ghostUser.UserID)
+		require.NoError(t, err, "Should get profile after avatar update")
+		assert.NotEmpty(t, updatedProfile.AvatarURL, "Avatar URL should be set")
+		// Avatar URL should be different from the original (if there was one)
+		if profile.AvatarURL != "" {
+			assert.NotEqual(t, profile.AvatarURL, updatedProfile.AvatarURL, "Avatar URL should be different")
+		}
+	})
+}
+
+// testMessageOperations tests message sending, editing, reactions, and redactions
+func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
+	// Create a test room and ghost user for message tests
+	roomIdentifier, err := client.CreateRoom("Message Test Room", "Testing messages", serverDomain, false, "test-message-channel")
+	require.NoError(t, err, "Should create room for message tests")
+
+	roomID, err := client.ResolveRoomAlias(roomIdentifier)
+	require.NoError(t, err, "Should resolve room identifier")
+
+	// Create ghost user for sending messages
+	mattermostUserID := "test-msg-user"
+	ghostUser, err := client.CreateGhostUser(mattermostUserID, "Message Test User", nil, "")
+	require.NoError(t, err, "Should create ghost user for messages")
+
+	// Join the ghost user to the room
+	err = client.JoinRoomAsUser(roomID, ghostUser.UserID)
+	require.NoError(t, err, "Should join ghost user to room")
+
+	t.Run("SendMessage", func(t *testing.T) {
+		// Send a text message
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			Message:     "Hello, this is a test message!",
+			HTMLMessage: "<p>Hello, this is a <strong>test</strong> message!</p>",
+			PostID:      "test-post-123",
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send message")
+		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
+		t.Logf("Sent message with event ID: %s", response.EventID)
+
+		// Verify the message was sent by retrieving it
+		event, err := client.GetEvent(roomID, response.EventID)
+		require.NoError(t, err, "Should retrieve sent message")
+		assert.Equal(t, "m.room.message", event["type"], "Event type should be m.room.message")
+
+		content, ok := event["content"].(map[string]any)
+		require.True(t, ok, "Event should have content")
+		assert.Equal(t, messageReq.Message, content["body"], "Message body should match")
+		assert.Equal(t, messageReq.HTMLMessage, content["formatted_body"], "HTML message should match")
+		assert.Equal(t, messageReq.PostID, content["mattermost_post_id"], "Post ID should match")
+	})
+
+	t.Run("EditMessage", func(t *testing.T) {
+		// Send original message
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			Message:     "Original message",
+			PostID:      "test-edit-post",
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send original message")
+
+		// Edit the message
+		newMessage := "Edited message content"
+		newHTMLMessage := "<p>Edited <em>message</em> content</p>"
+		editResponse, err := client.EditMessageAsGhost(roomID, response.EventID, newMessage, newHTMLMessage, ghostUser.UserID)
+		require.NoError(t, err, "Should edit message")
+		assert.NotEmpty(t, editResponse.EventID, "Edit event ID should not be empty")
+
+		// Verify the edit was applied by retrieving the edit event
+		editEvent, err := client.GetEvent(roomID, editResponse.EventID)
+		require.NoError(t, err, "Should retrieve edit event")
+
+		content, ok := editEvent["content"].(map[string]any)
+		require.True(t, ok, "Edit event should have content")
+
+		newContent, ok := content["m.new_content"].(map[string]any)
+		require.True(t, ok, "Edit should have m.new_content")
+		assert.Equal(t, newMessage, newContent["body"], "Edited message body should match")
+		assert.Equal(t, newHTMLMessage, newContent["formatted_body"], "Edited HTML should match")
+	})
+
+	t.Run("SendReaction", func(t *testing.T) {
+		// Send a message to react to
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			Message:     "React to this message!",
+			PostID:      "test-reaction-post",
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send message to react to")
+
+		// Send a reaction
+		emoji := "👍"
+		reactionResponse, err := client.SendReactionAsGhost(roomID, response.EventID, emoji, ghostUser.UserID)
+		require.NoError(t, err, "Should send reaction")
+		assert.NotEmpty(t, reactionResponse.EventID, "Reaction event ID should not be empty")
+
+		// Verify the reaction by getting relations
+		relations, err := client.GetEventRelationsAsUser(roomID, response.EventID, ghostUser.UserID)
+		require.NoError(t, err, "Should get event relations")
+		assert.NotEmpty(t, relations, "Should have at least one relation (the reaction)")
+
+		// Find our reaction in the relations
+		foundReaction := false
+		for _, relation := range relations {
+			if relation["type"] == "m.reaction" {
+				content, ok := relation["content"].(map[string]any)
+				if ok {
+					relatesTo, ok := content["m.relates_to"].(map[string]any)
+					if ok && relatesTo["key"] == emoji {
+						foundReaction = true
+						break
+					}
+				}
+			}
+		}
+		assert.True(t, foundReaction, "Should find the reaction in relations")
+	})
+
+	t.Run("RedactEvent", func(t *testing.T) {
+		// Send a message to redact
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			Message:     "This message will be deleted",
+			PostID:      "test-redact-post",
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send message to redact")
+
+		// Redact the message
+		redactResponse, err := client.RedactEventAsGhost(roomID, response.EventID, ghostUser.UserID)
+		require.NoError(t, err, "Should redact message")
+		assert.NotEmpty(t, redactResponse.EventID, "Redaction event ID should not be empty")
+
+		// Verify the original message is now redacted
+		// Note: Redacted events still exist but with limited content
+		event, err := client.GetEvent(roomID, response.EventID)
+		require.NoError(t, err, "Should still be able to get redacted event")
+
+		// Check if the event has been redacted (content should be empty or limited)
+		content, hasContent := event["content"].(map[string]any)
+		if hasContent {
+			// If content exists, it should be empty or only contain redaction-safe fields
+			body, hasBody := content["body"].(string)
+			if hasBody {
+				// Redacted events typically have empty body or placeholder text
+				assert.True(t, body == "" || strings.Contains(body, "redacted"),
+					"Redacted message should have empty or redacted body")
+			}
+		}
+	})
+}
+
+// testMediaOperations tests media upload and download operations
+func testMediaOperations(t *testing.T, client *Client) {
+	t.Run("UploadAndDownloadMedia", func(t *testing.T) {
+		// Test data
+		testData := []byte("This is test file content for upload/download testing")
+		filename := "test-file.txt"
+		contentType := "text/plain"
+
+		// Upload media
+		mxcURI, err := client.UploadMedia(testData, filename, contentType)
+		require.NoError(t, err, "Should upload media")
+		assert.NotEmpty(t, mxcURI, "MXC URI should not be empty")
+		assert.True(t, strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
+		t.Logf("Uploaded media: %s", mxcURI)
+
+		// Download the media back
+		downloadedData, err := client.DownloadFile(mxcURI, int64(len(testData)*2), "text/")
+		require.NoError(t, err, "Should download media")
+		assert.Equal(t, testData, downloadedData, "Downloaded data should match uploaded data")
+	})
+
+	t.Run("UploadAvatar", func(t *testing.T) {
+		// Test avatar upload
+		avatarData := []byte("fake-avatar-image-data")
+		contentType := "image/png"
+
+		mxcURI, err := client.UploadAvatarFromData(avatarData, contentType)
+		require.NoError(t, err, "Should upload avatar")
+		assert.NotEmpty(t, mxcURI, "Avatar MXC URI should not be empty")
+		assert.True(t, strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
+
+		// Verify we can download it back
+		downloadedData, err := client.DownloadFile(mxcURI, int64(len(avatarData)*2), "image/")
+		require.NoError(t, err, "Should download avatar")
+		assert.Equal(t, avatarData, downloadedData, "Downloaded avatar should match uploaded data")
+	})
+}
+
+// BenchmarkMatrixClientOperations provides performance benchmarks for key operations
+func BenchmarkMatrixClientOperations(b *testing.B) {
+	// Only run benchmarks if explicitly requested
+	if testing.Short() {
+		b.Skip("Skipping benchmark in short mode")
+	}
+
+	matrixContainer := matrixtest.StartMatrixContainer(&testing.T{}, matrixtest.DefaultMatrixConfig())
+	defer matrixContainer.Cleanup(&testing.T{})
+
+	client := NewClientWithLogger(
+		matrixContainer.ServerURL,
+		matrixContainer.ASToken,
+		"bench-remote-id",
+		NewTestLogger(&testing.T{}),
+	)
+	client.SetServerDomain(matrixContainer.ServerDomain)
+
+	b.Run("CreateRoom", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			roomName := fmt.Sprintf("Benchmark Room %d", i)
+			_, err := client.CreateRoom(roomName, "Benchmark test", matrixContainer.ServerDomain, false, fmt.Sprintf("bench-channel-%d", i))
+			if err != nil {
+				b.Fatalf("Failed to create room: %v", err)
+			}
+		}
+	})
+
+	b.Run("SendMessage", func(b *testing.B) {
+		// Create room and user once
+		roomID, _ := client.CreateRoom("Benchmark Messages", "Message benchmark", matrixContainer.ServerDomain, false, "bench-msg-channel")
+		resolvedRoomID, _ := client.ResolveRoomAlias(roomID)
+		ghostUser, _ := client.CreateGhostUser("bench-user", "Bench User", nil, "")
+		err := client.JoinRoomAsUser(resolvedRoomID, ghostUser.UserID)
+		require.NoError(&testing.T{}, err, "Should join ghost user to room")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			messageReq := MessageRequest{
+				RoomID:      resolvedRoomID,
+				GhostUserID: ghostUser.UserID,
+				Message:     fmt.Sprintf("Benchmark message %d", i),
+				PostID:      fmt.Sprintf("bench-post-%d", i),
+			}
+			_, err := client.SendMessage(messageReq)
+			if err != nil {
+				b.Fatalf("Failed to send message: %v", err)
+			}
+		}
+	})
+}
+
+// TestMatrixClientErrorHandling tests error handling and edge cases
+func TestMatrixClientErrorHandling(t *testing.T) {
+	// Start Matrix test container
+	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
+	defer matrixContainer.Cleanup(t)
+
+	// Create Matrix client
+	client := NewClientWithLogger(
+		matrixContainer.ServerURL,
+		matrixContainer.ASToken,
+		"test-remote-id",
+		NewTestLogger(t),
+	)
+	client.SetServerDomain(matrixContainer.ServerDomain)
+
+	t.Run("InvalidConfiguration", func(t *testing.T) {
+		// Test client with empty token
+		emptyTokenClient := NewClientWithLogger(
+			matrixContainer.ServerURL,
+			"", // Empty token
+			"test-remote-id",
+			NewTestLogger(t),
+		)
+
+		// Should fail operations that require authentication
+		_, err := emptyTokenClient.CreateRoom("Test", "Test", matrixContainer.ServerDomain, false, "test")
+		assert.Error(t, err, "Should fail with empty token")
+		assert.Contains(t, err.Error(), "not configured", "Error should mention configuration issue")
+
+		// Test client with invalid server URL
+		invalidURLClient := NewClientWithLogger(
+			"http://nonexistent.invalid:1234",
+			matrixContainer.ASToken,
+			"test-remote-id",
+			NewTestLogger(t),
+		)
+
+		err = invalidURLClient.TestConnection()
+		assert.Error(t, err, "Should fail with invalid server URL")
+	})
+
+	t.Run("InvalidRoomOperations", func(t *testing.T) {
+		// Test joining non-existent room
+		err := client.JoinRoom("!nonexistent:test.matrix.local")
+		assert.Error(t, err, "Should fail to join non-existent room")
+
+		// Test resolving non-existent alias
+		_, err = client.ResolveRoomAlias("#nonexistent:test.matrix.local")
+		assert.Error(t, err, "Should fail to resolve non-existent alias")
+
+		// Test creating DM with insufficient users
+		_, err = client.CreateDirectRoom([]string{"@user1:test.matrix.local"}, "Test DM")
+		assert.Error(t, err, "Should fail DM creation with only one user")
+		assert.Contains(t, err.Error(), "at least 2 users", "Error should mention user requirement")
+	})
+
+	t.Run("InvalidUserOperations", func(t *testing.T) {
+		// Test setting display name for non-existent user (should fail)
+		err := client.SetDisplayName("@nonexistent:test.matrix.local", "Test Name")
+		assert.Error(t, err, "Should fail to set display name for non-existent user")
+
+		// Test getting profile for non-existent user
+		profile, err := client.GetUserProfile("@nonexistent:test.matrix.local")
+		require.NoError(t, err, "Should not error for non-existent user profile") // Matrix returns empty profile
+		assert.Empty(t, profile.DisplayName, "Non-existent user should have empty profile")
+	})
+
+	t.Run("InvalidMessageOperations", func(t *testing.T) {
+		// Test sending message to non-existent room
+		messageReq := MessageRequest{
+			RoomID:      "!nonexistent:test.matrix.local",
+			GhostUserID: "@_mattermost_test:test.matrix.local",
+			Message:     "Test message",
+		}
+
+		_, err := client.SendMessage(messageReq)
+		assert.Error(t, err, "Should fail to send message to non-existent room")
+
+		// Test getting non-existent event
+		_, err = client.GetEvent("!nonexistent:test.matrix.local", "$nonexistent")
+		assert.Error(t, err, "Should fail to get non-existent event")
+
+		// Test empty message request
+		emptyReq := MessageRequest{
+			RoomID:      "!test:test.matrix.local",
+			GhostUserID: "@_mattermost_test:test.matrix.local",
+			// No message content
+		}
+
+		_, err = client.SendMessage(emptyReq)
+		assert.Error(t, err, "Should fail with empty message content")
+		assert.Contains(t, err.Error(), "no message content", "Error should mention missing content")
+	})
+
+	t.Run("InvalidMediaOperations", func(t *testing.T) {
+		// Test upload with empty data
+		// Note: Some servers might accept empty files, so we don't assert error here
+		_, _ = client.UploadMedia([]byte{}, "test.txt", "text/plain")
+
+		// Test download with invalid MXC URI
+		_, err := client.DownloadFile("invalid-uri", 1024, "")
+		assert.Error(t, err, "Should fail with invalid MXC URI")
+		assert.Contains(t, err.Error(), "invalid Matrix MXC URI", "Error should mention invalid URI")
+
+		// Test download with malformed MXC URI
+		_, err = client.DownloadFile("mxc://", 1024, "")
+		assert.Error(t, err, "Should fail with malformed MXC URI")
+
+		// Test avatar upload with empty data
+		_, err = client.UploadAvatarFromData([]byte{}, "image/png")
+		assert.Error(t, err, "Should fail with empty avatar data")
+		assert.Contains(t, err.Error(), "image data is empty", "Error should mention empty data")
+	})
+
+	t.Run("ParameterValidation", func(t *testing.T) {
+		// Test required parameter validation
+		messageReq := MessageRequest{
+			// Missing RoomID
+			GhostUserID: "@_mattermost_test:test.matrix.local",
+			Message:     "Test",
+		}
+
+		_, err := client.SendMessage(messageReq)
+		assert.Error(t, err, "Should fail with missing room ID")
+		assert.Contains(t, err.Error(), "room_id is required", "Error should mention room ID")
+
+		messageReq.RoomID = "!test:test.matrix.local"
+		messageReq.GhostUserID = "" // Missing ghost user ID
+
+		_, err = client.SendMessage(messageReq)
+		assert.Error(t, err, "Should fail with missing ghost user ID")
+		assert.Contains(t, err.Error(), "ghost_user_id is required", "Error should mention ghost user ID")
+	})
+
+	t.Run("NetworkErrorHandling", func(t *testing.T) {
+		// Test with client pointing to a port that definitely doesn't exist
+		networkFailClient := NewClientWithLogger(
+			"http://localhost:99999", // Port that should be unused
+			matrixContainer.ASToken,
+			"test-remote-id",
+			NewTestLogger(t),
+		)
+
+		// All operations should fail with network errors
+		err := networkFailClient.TestConnection()
+		assert.Error(t, err, "Should fail with network error")
+
+		_, err = networkFailClient.CreateRoom("Test", "Test", "test.local", false, "test")
+		assert.Error(t, err, "Should fail with network error")
+
+		_, err = networkFailClient.GetServerInfo()
+		assert.Error(t, err, "Should fail with network error")
+	})
+}
+
+// TestMatrixClientWithFiles tests file attachment handling
+func TestMatrixClientWithFiles(t *testing.T) {
+	// Start Matrix test container
+	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
+	defer matrixContainer.Cleanup(t)
+
+	// Create Matrix client
+	client := NewClientWithLogger(
+		matrixContainer.ServerURL,
+		matrixContainer.ASToken,
+		"test-remote-id",
+		NewTestLogger(t),
+	)
+	client.SetServerDomain(matrixContainer.ServerDomain)
+
+	// Create test room and user
+	roomIdentifier, err := client.CreateRoom("File Test Room", "Testing file attachments", matrixContainer.ServerDomain, false, "test-file-channel")
+	require.NoError(t, err, "Should create room for file tests")
+
+	roomID, err := client.ResolveRoomAlias(roomIdentifier)
+	require.NoError(t, err, "Should resolve room identifier")
+
+	ghostUser, err := client.CreateGhostUser("test-file-user", "File Test User", nil, "")
+	require.NoError(t, err, "Should create ghost user for file tests")
+
+	err = client.JoinRoomAsUser(roomID, ghostUser.UserID)
+	require.NoError(t, err, "Should join ghost user to room")
+
+	t.Run("SendMessageWithFiles", func(t *testing.T) {
+		// Upload test files first
+		testFileData := []byte("This is a test file content for attachment testing")
+		testImageData := []byte("fake-image-data-for-testing")
+
+		fileMxcURI, err := client.UploadMedia(testFileData, "test-document.txt", "text/plain")
+		require.NoError(t, err, "Should upload test file")
+
+		imageMxcURI, err := client.UploadMedia(testImageData, "test-image.png", "image/png")
+		require.NoError(t, err, "Should upload test image")
+
+		// Send message with file attachments
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			Message:     "Here are some file attachments",
+			PostID:      "test-file-post-123",
+			Files: []FileAttachment{
+				{
+					Filename: "test-document.txt",
+					MxcURI:   fileMxcURI,
+					MimeType: "text/plain",
+					Size:     int64(len(testFileData)),
+				},
+				{
+					Filename: "test-image.png",
+					MxcURI:   imageMxcURI,
+					MimeType: "image/png",
+					Size:     int64(len(testImageData)),
+				},
+			},
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send message with files")
+		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
+
+		// Verify we can download the files back
+		downloadedFile, err := client.DownloadFile(fileMxcURI, int64(len(testFileData)*2), "text/")
+		require.NoError(t, err, "Should download file")
+		assert.Equal(t, testFileData, downloadedFile, "Downloaded file should match uploaded data")
+
+		downloadedImage, err := client.DownloadFile(imageMxcURI, int64(len(testImageData)*2), "image/")
+		require.NoError(t, err, "Should download image")
+		assert.Equal(t, testImageData, downloadedImage, "Downloaded image should match uploaded data")
+	})
+
+	t.Run("SendOnlyFiles", func(t *testing.T) {
+		// Upload test file
+		testData := []byte("File-only message test content")
+		mxcURI, err := client.UploadMedia(testData, "file-only.txt", "text/plain")
+		require.NoError(t, err, "Should upload test file")
+
+		// Send message with only files (no text)
+		messageReq := MessageRequest{
+			RoomID:      roomID,
+			GhostUserID: ghostUser.UserID,
+			// No Message text
+			PostID: "test-file-only-post",
+			Files: []FileAttachment{
+				{
+					Filename: "file-only.txt",
+					MxcURI:   mxcURI,
+					MimeType: "text/plain",
+					Size:     int64(len(testData)),
+				},
+			},
+		}
+
+		response, err := client.SendMessage(messageReq)
+		require.NoError(t, err, "Should send file-only message")
+		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
+	})
+}

--- a/server/matrix/client_test.go
+++ b/server/matrix/client_test.go
@@ -7,208 +7,217 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	matrixtest "github.com/wiggin77/mattermost-plugin-matrix-bridge/testcontainers/matrix"
 )
 
-// TestMatrixClientOperations tests core Matrix client operations that affect change
-// and then query the server to verify the changes were applied correctly.
-// This approach validates compatibility across different Matrix server implementations.
-func TestMatrixClientOperations(t *testing.T) {
-	// Start Matrix test container
-	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
-	defer matrixContainer.Cleanup(t)
+// MatrixClientTestSuite contains integration tests for Matrix client operations
+type MatrixClientTestSuite struct {
+	suite.Suite
+	matrixContainer *matrixtest.MatrixContainer
+	client          *Client
+}
+
+// SetupSuite starts the Matrix container before running tests
+func (suite *MatrixClientTestSuite) SetupSuite() {
+	suite.matrixContainer = matrixtest.StartMatrixContainer(suite.T(), matrixtest.DefaultMatrixConfig())
+}
+
+// TearDownSuite cleans up the Matrix container after tests
+func (suite *MatrixClientTestSuite) TearDownSuite() {
+	if suite.matrixContainer != nil {
+		suite.matrixContainer.Cleanup(suite.T())
+	}
+}
+
+// SetupTest prepares each test with fresh Matrix client and ensures AS bot is created
+func (suite *MatrixClientTestSuite) SetupTest() {
+	// Create a test room to ensure AS bot user is provisioned
+	_ = suite.matrixContainer.CreateRoom(suite.T(), "AS Bot Provisioning Room")
 
 	// Create Matrix client
-	client := NewClientWithLogger(
-		matrixContainer.ServerURL,
-		matrixContainer.ASToken,
+	suite.client = NewClientWithLogger(
+		suite.matrixContainer.ServerURL,
+		suite.matrixContainer.ASToken,
 		"test-remote-id",
-		NewTestLogger(t),
+		NewTestLogger(suite.T()),
 	)
-	client.SetServerDomain(matrixContainer.ServerDomain)
+	suite.client.SetServerDomain(suite.matrixContainer.ServerDomain)
+}
+
+// TestMatrixClientOperations tests core Matrix client operations that affect change
+// and then query the server to verify the changes were applied correctly.
+func (suite *MatrixClientTestSuite) TestMatrixClientOperations() {
 
 	// Test server connectivity first
-	t.Run("TestConnection", func(t *testing.T) {
-		err := client.TestConnection()
-		require.NoError(t, err, "Should connect to Matrix server")
+	suite.Run("TestConnection", func() {
+		err := suite.client.TestConnection()
+		require.NoError(suite.T(), err, "Should connect to Matrix server")
 	})
 
 	// Test Application Service permissions
-	t.Run("TestApplicationServicePermissions", func(t *testing.T) {
-		err := client.TestApplicationServicePermissions()
-		require.NoError(t, err, "Should have proper AS permissions")
+	suite.Run("TestApplicationServicePermissions", func() {
+		err := suite.client.TestApplicationServicePermissions()
+		require.NoError(suite.T(), err, "Should have proper AS permissions")
 	})
 
 	// Test server information retrieval
-	t.Run("GetServerInfo", func(t *testing.T) {
-		serverInfo, err := client.GetServerInfo()
-		require.NoError(t, err, "Should retrieve server info")
-		assert.NotEmpty(t, serverInfo.Name, "Server name should not be empty")
-		t.Logf("Server: %s %s", serverInfo.Name, serverInfo.Version)
+	suite.Run("GetServerInfo", func() {
+		serverInfo, err := suite.client.GetServerInfo()
+		require.NoError(suite.T(), err, "Should retrieve server info")
+		assert.NotEmpty(suite.T(), serverInfo.Name, "Server name should not be empty")
+		suite.T().Logf("Server: %s %s", serverInfo.Name, serverInfo.Version)
 	})
 
 	// Run room operation tests
-	t.Run("RoomOperations", func(t *testing.T) {
-		testRoomOperations(t, client, matrixContainer.ServerDomain)
+	suite.Run("RoomOperations", func() {
+		suite.testRoomOperations()
 	})
 
 	// Run user operation tests
-	t.Run("UserOperations", func(t *testing.T) {
-		testUserOperations(t, client)
+	suite.Run("UserOperations", func() {
+		suite.testUserOperations()
 	})
 
 	// Run message operation tests
-	t.Run("MessageOperations", func(t *testing.T) {
-		testMessageOperations(t, client, matrixContainer.ServerDomain)
+	suite.Run("MessageOperations", func() {
+		suite.testMessageOperations()
 	})
 
 	// Run media operation tests
-	t.Run("MediaOperations", func(t *testing.T) {
-		testMediaOperations(t, client)
+	suite.Run("MediaOperations", func() {
+		suite.testMediaOperations()
 	})
 }
 
 // testRoomOperations tests room creation, joining, and management operations
-func testRoomOperations(t *testing.T, client *Client, serverDomain string) {
-	t.Run("CreateRoom", func(t *testing.T) {
+func (suite *MatrixClientTestSuite) testRoomOperations() {
+	suite.Run("CreateRoom", func() {
 		// Create a room and verify it exists
 		roomName := "Test Room"
 		roomTopic := "Integration test room"
 		mattermostChannelID := "test-channel-123"
 
-		roomIdentifier, err := client.CreateRoom(roomName, roomTopic, serverDomain, true, mattermostChannelID)
-		require.NoError(t, err, "Should create room successfully")
-		assert.NotEmpty(t, roomIdentifier, "Room identifier should not be empty")
-		t.Logf("Created room: %s", roomIdentifier)
-
-		// Verify room was created by resolving the identifier
-		roomID, err := client.ResolveRoomAlias(roomIdentifier)
-		require.NoError(t, err, "Should resolve room identifier")
-		assert.NotEmpty(t, roomID, "Room ID should not be empty")
-		assert.True(t, strings.HasPrefix(roomID, "!"), "Room ID should start with !")
-
-		// Verify Mattermost channel ID was stored in room state
-		retrievedChannelID, err := client.GetMattermostChannelID(roomID)
-		require.NoError(t, err, "Should retrieve Mattermost channel ID")
-		assert.Equal(t, mattermostChannelID, retrievedChannelID, "Channel ID should match")
+		roomIdentifier, err := suite.client.CreateRoom(roomName, roomTopic, suite.matrixContainer.ServerDomain, true, mattermostChannelID)
+		require.NoError(suite.T(), err, "Should create room successfully")
+		assert.NotEmpty(suite.T(), roomIdentifier, "Room identifier should not be empty")
+		suite.T().Logf("Created room: %s", roomIdentifier)
 	})
 
-	t.Run("CreateDirectRoom", func(t *testing.T) {
-		// Create ghost users for DM
-		ghostUser1 := "@_mattermost_user1:" + serverDomain
-		ghostUser2 := "@_mattermost_user2:" + serverDomain
-		ghostUserIDs := []string{ghostUser1, ghostUser2}
-
-		roomID, err := client.CreateDirectRoom(ghostUserIDs, "Test DM")
-		require.NoError(t, err, "Should create direct room")
-		assert.NotEmpty(t, roomID, "Room ID should not be empty")
-		assert.True(t, strings.HasPrefix(roomID, "!"), "Room ID should start with !")
-		t.Logf("Created DM room: %s", roomID)
-	})
-
-	t.Run("JoinRoom", func(t *testing.T) {
+	suite.Run("JoinRoom", func() {
 		// Create a room first
-		roomIdentifier, err := client.CreateRoom("Join Test Room", "Test joining", serverDomain, false, "test-join-channel")
-		require.NoError(t, err, "Should create room for join test")
+		roomIdentifier, err := suite.client.CreateRoom("Join Test Room", "Testing room joining", suite.matrixContainer.ServerDomain, false, "test-join-channel")
+		require.NoError(suite.T(), err, "Should create room for join test")
 
-		// Join the room (AS should already be in room, but test the API)
-		err = client.JoinRoom(roomIdentifier)
-		require.NoError(t, err, "Should join room successfully")
+		// Join the room as the AS bot
+		err = suite.client.JoinRoom(roomIdentifier)
+		require.NoError(suite.T(), err, "Should join room successfully")
 	})
 
-	t.Run("AddRoomAlias", func(t *testing.T) {
-		// Create a room
-		roomIdentifier, err := client.CreateRoom("Alias Test Room", "Test aliases", serverDomain, false, "test-alias-channel")
-		require.NoError(t, err, "Should create room for alias test")
+	suite.Run("ResolveRoomAlias", func() {
+		// Create a room first
+		roomIdentifier, err := suite.client.CreateRoom("Resolve Test Room", "Testing alias resolution", suite.matrixContainer.ServerDomain, false, "test-resolve-channel")
+		require.NoError(suite.T(), err, "Should create room for alias test")
 
-		roomID, err := client.ResolveRoomAlias(roomIdentifier)
-		require.NoError(t, err, "Should resolve room identifier")
+		// Resolve the alias to room ID
+		roomID, err := suite.client.ResolveRoomAlias(roomIdentifier)
+		require.NoError(suite.T(), err, "Should resolve room alias")
+		assert.NotEmpty(suite.T(), roomID, "Room ID should not be empty")
+		assert.True(suite.T(), strings.HasPrefix(roomID, "!"), "Room ID should start with !")
+		suite.T().Logf("Resolved %s to %s", roomIdentifier, roomID)
+	})
 
-		// Add an additional alias within the reserved namespace
-		additionalAlias := "#_mattermost_additional-alias-test:" + serverDomain
-		err = client.AddRoomAlias(roomID, additionalAlias)
-		require.NoError(t, err, "Should add room alias")
+	suite.Run("CreateDirectRoom", func() {
+		// Create ghost users for DM
+		ghostUser1, err := suite.client.CreateGhostUser("dm-user-1", "DM User 1", nil, "")
+		require.NoError(suite.T(), err, "Should create first ghost user")
 
-		// Verify the alias resolves to the same room
-		resolvedRoomID, err := client.ResolveRoomAlias(additionalAlias)
-		require.NoError(t, err, "Should resolve additional alias")
-		assert.Equal(t, roomID, resolvedRoomID, "Additional alias should resolve to same room")
+		ghostUser2, err := suite.client.CreateGhostUser("dm-user-2", "DM User 2", nil, "")
+		require.NoError(suite.T(), err, "Should create second ghost user")
+
+		// Create direct room between the users
+		ghostUserIDs := []string{ghostUser1.UserID, ghostUser2.UserID}
+		roomID, err := suite.client.CreateDirectRoom(ghostUserIDs, "Test Direct Message")
+		require.NoError(suite.T(), err, "Should create direct room")
+		assert.NotEmpty(suite.T(), roomID, "Room ID should not be empty")
+		assert.True(suite.T(), strings.HasPrefix(roomID, "!"), "Room ID should start with !")
+		suite.T().Logf("Created DM room: %s", roomID)
 	})
 }
 
 // testUserOperations tests user creation and profile management operations
-func testUserOperations(t *testing.T, client *Client) {
-	t.Run("CreateGhostUser", func(t *testing.T) {
+func (suite *MatrixClientTestSuite) testUserOperations() {
+	suite.Run("CreateGhostUser", func() {
 		mattermostUserID := "test-user-123"
 		displayName := "Test User"
 		avatarData := []byte("fake-avatar-data")
 		avatarContentType := "image/png"
 
-		ghostUser, err := client.CreateGhostUser(mattermostUserID, displayName, avatarData, avatarContentType)
-		require.NoError(t, err, "Should create ghost user")
-		assert.NotNil(t, ghostUser, "Ghost user should not be nil")
-		assert.NotEmpty(t, ghostUser.UserID, "Ghost user ID should not be empty")
-		assert.Contains(t, ghostUser.UserID, mattermostUserID, "Ghost user ID should contain Mattermost user ID")
-		t.Logf("Created ghost user: %s", ghostUser.UserID)
+		ghostUser, err := suite.client.CreateGhostUser(mattermostUserID, displayName, avatarData, avatarContentType)
+		require.NoError(suite.T(), err, "Should create ghost user")
+		assert.NotNil(suite.T(), ghostUser, "Ghost user should not be nil")
+		assert.NotEmpty(suite.T(), ghostUser.UserID, "Ghost user ID should not be empty")
+		assert.Contains(suite.T(), ghostUser.UserID, mattermostUserID, "Ghost user ID should contain Mattermost user ID")
+		suite.T().Logf("Created ghost user: %s", ghostUser.UserID)
 
 		// Verify user profile was set correctly
-		profile, err := client.GetUserProfile(ghostUser.UserID)
-		require.NoError(t, err, "Should get user profile")
-		assert.Equal(t, displayName, profile.DisplayName, "Display name should match")
-		assert.NotEmpty(t, profile.AvatarURL, "Avatar URL should be set")
+		profile, err := suite.client.GetUserProfile(ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should get user profile")
+		assert.Equal(suite.T(), displayName, profile.DisplayName, "Display name should match")
+		assert.NotEmpty(suite.T(), profile.AvatarURL, "Avatar URL should be set")
 	})
 
-	t.Run("UpdateUserProfile", func(t *testing.T) {
+	suite.Run("UpdateUserProfile", func() {
 		// Create a ghost user first
 		mattermostUserID := "test-user-456"
-		ghostUser, err := client.CreateGhostUser(mattermostUserID, "Original Name", nil, "")
-		require.NoError(t, err, "Should create ghost user for profile test")
+		ghostUser, err := suite.client.CreateGhostUser(mattermostUserID, "Original Name", nil, "")
+		require.NoError(suite.T(), err, "Should create ghost user for profile test")
 
 		// Update display name
 		newDisplayName := "Updated Display Name"
-		err = client.SetDisplayName(ghostUser.UserID, newDisplayName)
-		require.NoError(t, err, "Should update display name")
+		err = suite.client.SetDisplayName(ghostUser.UserID, newDisplayName)
+		require.NoError(suite.T(), err, "Should update display name")
 
 		// Verify the change
-		profile, err := client.GetUserProfile(ghostUser.UserID)
-		require.NoError(t, err, "Should get updated profile")
-		assert.Equal(t, newDisplayName, profile.DisplayName, "Display name should be updated")
+		profile, err := suite.client.GetUserProfile(ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should get updated profile")
+		assert.Equal(suite.T(), newDisplayName, profile.DisplayName, "Display name should be updated")
 
 		// Update avatar
 		newAvatarData := []byte("new-fake-avatar-data")
-		err = client.UpdateGhostUserAvatar(ghostUser.UserID, newAvatarData, "image/jpeg")
-		require.NoError(t, err, "Should update avatar")
+		err = suite.client.UpdateGhostUserAvatar(ghostUser.UserID, newAvatarData, "image/jpeg")
+		require.NoError(suite.T(), err, "Should update avatar")
 
 		// Verify avatar was updated
-		updatedProfile, err := client.GetUserProfile(ghostUser.UserID)
-		require.NoError(t, err, "Should get profile after avatar update")
-		assert.NotEmpty(t, updatedProfile.AvatarURL, "Avatar URL should be set")
+		updatedProfile, err := suite.client.GetUserProfile(ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should get profile after avatar update")
+		assert.NotEmpty(suite.T(), updatedProfile.AvatarURL, "Avatar URL should be set")
 		// Avatar URL should be different from the original (if there was one)
 		if profile.AvatarURL != "" {
-			assert.NotEqual(t, profile.AvatarURL, updatedProfile.AvatarURL, "Avatar URL should be different")
+			assert.NotEqual(suite.T(), profile.AvatarURL, updatedProfile.AvatarURL, "Avatar URL should be different")
 		}
 	})
 }
 
 // testMessageOperations tests message sending, editing, reactions, and redactions
-func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
+func (suite *MatrixClientTestSuite) testMessageOperations() {
 	// Create a test room and ghost user for message tests
-	roomIdentifier, err := client.CreateRoom("Message Test Room", "Testing messages", serverDomain, false, "test-message-channel")
-	require.NoError(t, err, "Should create room for message tests")
+	roomIdentifier, err := suite.client.CreateRoom("Message Test Room", "Testing messages", suite.matrixContainer.ServerDomain, false, "test-message-channel")
+	require.NoError(suite.T(), err, "Should create room for message tests")
 
-	roomID, err := client.ResolveRoomAlias(roomIdentifier)
-	require.NoError(t, err, "Should resolve room identifier")
+	roomID, err := suite.client.ResolveRoomAlias(roomIdentifier)
+	require.NoError(suite.T(), err, "Should resolve room identifier")
 
 	// Create ghost user for sending messages
 	mattermostUserID := "test-msg-user"
-	ghostUser, err := client.CreateGhostUser(mattermostUserID, "Message Test User", nil, "")
-	require.NoError(t, err, "Should create ghost user for messages")
+	ghostUser, err := suite.client.CreateGhostUser(mattermostUserID, "Message Test User", nil, "")
+	require.NoError(suite.T(), err, "Should create ghost user for messages")
 
 	// Join the ghost user to the room
-	err = client.JoinRoomAsUser(roomID, ghostUser.UserID)
-	require.NoError(t, err, "Should join ghost user to room")
+	err = suite.client.JoinRoomAsUser(roomID, ghostUser.UserID)
+	require.NoError(suite.T(), err, "Should join ghost user to room")
 
-	t.Run("SendMessage", func(t *testing.T) {
+	suite.Run("SendMessage", func() {
 		// Send a text message
 		messageReq := MessageRequest{
 			RoomID:      roomID,
@@ -218,24 +227,24 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 			PostID:      "test-post-123",
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send message")
-		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
-		t.Logf("Sent message with event ID: %s", response.EventID)
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send message")
+		assert.NotEmpty(suite.T(), response.EventID, "Event ID should not be empty")
+		suite.T().Logf("Sent message with event ID: %s", response.EventID)
 
 		// Verify the message was sent by retrieving it
-		event, err := client.GetEvent(roomID, response.EventID)
-		require.NoError(t, err, "Should retrieve sent message")
-		assert.Equal(t, "m.room.message", event["type"], "Event type should be m.room.message")
+		event, err := suite.client.GetEvent(roomID, response.EventID)
+		require.NoError(suite.T(), err, "Should retrieve sent message")
+		assert.Equal(suite.T(), "m.room.message", event["type"], "Event type should be m.room.message")
 
 		content, ok := event["content"].(map[string]any)
-		require.True(t, ok, "Event should have content")
-		assert.Equal(t, messageReq.Message, content["body"], "Message body should match")
-		assert.Equal(t, messageReq.HTMLMessage, content["formatted_body"], "HTML message should match")
-		assert.Equal(t, messageReq.PostID, content["mattermost_post_id"], "Post ID should match")
+		require.True(suite.T(), ok, "Event should have content")
+		assert.Equal(suite.T(), messageReq.Message, content["body"], "Message body should match")
+		assert.Equal(suite.T(), messageReq.HTMLMessage, content["formatted_body"], "HTML message should match")
+		assert.Equal(suite.T(), messageReq.PostID, content["mattermost_post_id"], "Post ID should match")
 	})
 
-	t.Run("EditMessage", func(t *testing.T) {
+	suite.Run("EditMessage", func() {
 		// Send original message
 		messageReq := MessageRequest{
 			RoomID:      roomID,
@@ -244,30 +253,30 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 			PostID:      "test-edit-post",
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send original message")
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send original message")
 
 		// Edit the message
 		newMessage := "Edited message content"
 		newHTMLMessage := "<p>Edited <em>message</em> content</p>"
-		editResponse, err := client.EditMessageAsGhost(roomID, response.EventID, newMessage, newHTMLMessage, ghostUser.UserID)
-		require.NoError(t, err, "Should edit message")
-		assert.NotEmpty(t, editResponse.EventID, "Edit event ID should not be empty")
+		editResponse, err := suite.client.EditMessageAsGhost(roomID, response.EventID, newMessage, newHTMLMessage, ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should edit message")
+		assert.NotEmpty(suite.T(), editResponse.EventID, "Edit event ID should not be empty")
 
 		// Verify the edit was applied by retrieving the edit event
-		editEvent, err := client.GetEvent(roomID, editResponse.EventID)
-		require.NoError(t, err, "Should retrieve edit event")
+		editEvent, err := suite.client.GetEvent(roomID, editResponse.EventID)
+		require.NoError(suite.T(), err, "Should retrieve edit event")
 
 		content, ok := editEvent["content"].(map[string]any)
-		require.True(t, ok, "Edit event should have content")
+		require.True(suite.T(), ok, "Edit event should have content")
 
 		newContent, ok := content["m.new_content"].(map[string]any)
-		require.True(t, ok, "Edit should have m.new_content")
-		assert.Equal(t, newMessage, newContent["body"], "Edited message body should match")
-		assert.Equal(t, newHTMLMessage, newContent["formatted_body"], "Edited HTML should match")
+		require.True(suite.T(), ok, "Edit should have m.new_content")
+		assert.Equal(suite.T(), newMessage, newContent["body"], "Edited message body should match")
+		assert.Equal(suite.T(), newHTMLMessage, newContent["formatted_body"], "Edited HTML should match")
 	})
 
-	t.Run("SendReaction", func(t *testing.T) {
+	suite.Run("SendReaction", func() {
 		// Send a message to react to
 		messageReq := MessageRequest{
 			RoomID:      roomID,
@@ -276,19 +285,19 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 			PostID:      "test-reaction-post",
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send message to react to")
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send message to react to")
 
 		// Send a reaction
 		emoji := "👍"
-		reactionResponse, err := client.SendReactionAsGhost(roomID, response.EventID, emoji, ghostUser.UserID)
-		require.NoError(t, err, "Should send reaction")
-		assert.NotEmpty(t, reactionResponse.EventID, "Reaction event ID should not be empty")
+		reactionResponse, err := suite.client.SendReactionAsGhost(roomID, response.EventID, emoji, ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should send reaction")
+		assert.NotEmpty(suite.T(), reactionResponse.EventID, "Reaction event ID should not be empty")
 
 		// Verify the reaction by getting relations
-		relations, err := client.GetEventRelationsAsUser(roomID, response.EventID, ghostUser.UserID)
-		require.NoError(t, err, "Should get event relations")
-		assert.NotEmpty(t, relations, "Should have at least one relation (the reaction)")
+		relations, err := suite.client.GetEventRelationsAsUser(roomID, response.EventID, ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should get event relations")
+		assert.NotEmpty(suite.T(), relations, "Should have at least one relation (the reaction)")
 
 		// Find our reaction in the relations
 		foundReaction := false
@@ -304,10 +313,10 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 				}
 			}
 		}
-		assert.True(t, foundReaction, "Should find the reaction in relations")
+		assert.True(suite.T(), foundReaction, "Should find the reaction in relations")
 	})
 
-	t.Run("RedactEvent", func(t *testing.T) {
+	suite.Run("RedactEvent", func() {
 		// Send a message to redact
 		messageReq := MessageRequest{
 			RoomID:      roomID,
@@ -316,18 +325,18 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 			PostID:      "test-redact-post",
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send message to redact")
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send message to redact")
 
 		// Redact the message
-		redactResponse, err := client.RedactEventAsGhost(roomID, response.EventID, ghostUser.UserID)
-		require.NoError(t, err, "Should redact message")
-		assert.NotEmpty(t, redactResponse.EventID, "Redaction event ID should not be empty")
+		redactResponse, err := suite.client.RedactEventAsGhost(roomID, response.EventID, ghostUser.UserID)
+		require.NoError(suite.T(), err, "Should redact message")
+		assert.NotEmpty(suite.T(), redactResponse.EventID, "Redaction event ID should not be empty")
 
 		// Verify the original message is now redacted
 		// Note: Redacted events still exist but with limited content
-		event, err := client.GetEvent(roomID, response.EventID)
-		require.NoError(t, err, "Should still be able to get redacted event")
+		event, err := suite.client.GetEvent(roomID, response.EventID)
+		require.NoError(suite.T(), err, "Should still be able to get redacted event")
 
 		// Check if the event has been redacted (content should be empty or limited)
 		content, hasContent := event["content"].(map[string]any)
@@ -336,7 +345,7 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 			body, hasBody := content["body"].(string)
 			if hasBody {
 				// Redacted events typically have empty body or placeholder text
-				assert.True(t, body == "" || strings.Contains(body, "redacted"),
+				assert.True(suite.T(), body == "" || strings.Contains(body, "redacted"),
 					"Redacted message should have empty or redacted body")
 			}
 		}
@@ -344,40 +353,40 @@ func testMessageOperations(t *testing.T, client *Client, serverDomain string) {
 }
 
 // testMediaOperations tests media upload and download operations
-func testMediaOperations(t *testing.T, client *Client) {
-	t.Run("UploadAndDownloadMedia", func(t *testing.T) {
+func (suite *MatrixClientTestSuite) testMediaOperations() {
+	suite.Run("UploadAndDownloadMedia", func() {
 		// Test data
 		testData := []byte("This is test file content for upload/download testing")
 		filename := "test-file.txt"
 		contentType := "text/plain"
 
 		// Upload media
-		mxcURI, err := client.UploadMedia(testData, filename, contentType)
-		require.NoError(t, err, "Should upload media")
-		assert.NotEmpty(t, mxcURI, "MXC URI should not be empty")
-		assert.True(t, strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
-		t.Logf("Uploaded media: %s", mxcURI)
+		mxcURI, err := suite.client.UploadMedia(testData, filename, contentType)
+		require.NoError(suite.T(), err, "Should upload media")
+		assert.NotEmpty(suite.T(), mxcURI, "MXC URI should not be empty")
+		assert.True(suite.T(), strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
+		suite.T().Logf("Uploaded media: %s", mxcURI)
 
 		// Download the media back
-		downloadedData, err := client.DownloadFile(mxcURI, int64(len(testData)*2), "text/")
-		require.NoError(t, err, "Should download media")
-		assert.Equal(t, testData, downloadedData, "Downloaded data should match uploaded data")
+		downloadedData, err := suite.client.DownloadFile(mxcURI, int64(len(testData)*2), "text/")
+		require.NoError(suite.T(), err, "Should download media")
+		assert.Equal(suite.T(), testData, downloadedData, "Downloaded data should match uploaded data")
 	})
 
-	t.Run("UploadAvatar", func(t *testing.T) {
+	suite.Run("UploadAvatar", func() {
 		// Test avatar upload
 		avatarData := []byte("fake-avatar-image-data")
 		contentType := "image/png"
 
-		mxcURI, err := client.UploadAvatarFromData(avatarData, contentType)
-		require.NoError(t, err, "Should upload avatar")
-		assert.NotEmpty(t, mxcURI, "Avatar MXC URI should not be empty")
-		assert.True(t, strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
+		mxcURI, err := suite.client.UploadAvatarFromData(avatarData, contentType)
+		require.NoError(suite.T(), err, "Should upload avatar")
+		assert.NotEmpty(suite.T(), mxcURI, "Avatar MXC URI should not be empty")
+		assert.True(suite.T(), strings.HasPrefix(mxcURI, "mxc://"), "Should return valid MXC URI")
 
 		// Verify we can download it back
-		downloadedData, err := client.DownloadFile(mxcURI, int64(len(avatarData)*2), "image/")
-		require.NoError(t, err, "Should download avatar")
-		assert.Equal(t, avatarData, downloadedData, "Downloaded avatar should match uploaded data")
+		downloadedData, err := suite.client.DownloadFile(mxcURI, int64(len(avatarData)*2), "image/")
+		require.NoError(suite.T(), err, "Should download avatar")
+		assert.Equal(suite.T(), avatarData, downloadedData, "Downloaded avatar should match uploaded data")
 	})
 }
 
@@ -390,6 +399,9 @@ func BenchmarkMatrixClientOperations(b *testing.B) {
 
 	matrixContainer := matrixtest.StartMatrixContainer(&testing.T{}, matrixtest.DefaultMatrixConfig())
 	defer matrixContainer.Cleanup(&testing.T{})
+
+	// Create a test room to ensure AS bot user is provisioned
+	_ = matrixContainer.CreateRoom(&testing.T{}, "AS Bot Provisioning Room")
 
 	client := NewClientWithLogger(
 		matrixContainer.ServerURL,
@@ -434,73 +446,62 @@ func BenchmarkMatrixClientOperations(b *testing.B) {
 }
 
 // TestMatrixClientErrorHandling tests error handling and edge cases
-func TestMatrixClientErrorHandling(t *testing.T) {
-	// Start Matrix test container
-	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
-	defer matrixContainer.Cleanup(t)
-
-	// Create Matrix client
-	client := NewClientWithLogger(
-		matrixContainer.ServerURL,
-		matrixContainer.ASToken,
-		"test-remote-id",
-		NewTestLogger(t),
-	)
-	client.SetServerDomain(matrixContainer.ServerDomain)
-
-	t.Run("InvalidConfiguration", func(t *testing.T) {
+func (suite *MatrixClientTestSuite) TestMatrixClientErrorHandling() {
+	suite.Run("EmptyTokenClient", func() {
 		// Test client with empty token
 		emptyTokenClient := NewClientWithLogger(
-			matrixContainer.ServerURL,
+			suite.matrixContainer.ServerURL,
 			"", // Empty token
 			"test-remote-id",
-			NewTestLogger(t),
+			NewTestLogger(suite.T()),
 		)
 
 		// Should fail operations that require authentication
-		_, err := emptyTokenClient.CreateRoom("Test", "Test", matrixContainer.ServerDomain, false, "test")
-		assert.Error(t, err, "Should fail with empty token")
-		assert.Contains(t, err.Error(), "not configured", "Error should mention configuration issue")
+		_, err := emptyTokenClient.CreateRoom("Test", "Test", suite.matrixContainer.ServerDomain, false, "test")
+		assert.Error(suite.T(), err, "Should fail with empty token")
+		assert.Contains(suite.T(), err.Error(), "not configured", "Error should mention configuration issue")
+	})
 
+	suite.Run("InvalidServerURL", func() {
 		// Test client with invalid server URL
 		invalidURLClient := NewClientWithLogger(
 			"http://nonexistent.invalid:1234",
-			matrixContainer.ASToken,
+			suite.matrixContainer.ASToken,
 			"test-remote-id",
-			NewTestLogger(t),
+			NewTestLogger(suite.T()),
 		)
 
-		err = invalidURLClient.TestConnection()
-		assert.Error(t, err, "Should fail with invalid server URL")
+		err := invalidURLClient.TestConnection()
+		assert.Error(suite.T(), err, "Should fail with invalid server URL")
 	})
 
-	t.Run("InvalidRoomOperations", func(t *testing.T) {
+	suite.Run("InvalidRoomOperations", func() {
 		// Test joining non-existent room
-		err := client.JoinRoom("!nonexistent:test.matrix.local")
-		assert.Error(t, err, "Should fail to join non-existent room")
+		err := suite.client.JoinRoom("!nonexistent:test.matrix.local")
+		assert.Error(suite.T(), err, "Should fail to join non-existent room")
 
 		// Test resolving non-existent alias
-		_, err = client.ResolveRoomAlias("#nonexistent:test.matrix.local")
-		assert.Error(t, err, "Should fail to resolve non-existent alias")
+		_, err = suite.client.ResolveRoomAlias("#nonexistent:test.matrix.local")
+		assert.Error(suite.T(), err, "Should fail to resolve non-existent alias")
 
 		// Test creating DM with insufficient users
-		_, err = client.CreateDirectRoom([]string{"@user1:test.matrix.local"}, "Test DM")
-		assert.Error(t, err, "Should fail DM creation with only one user")
-		assert.Contains(t, err.Error(), "at least 2 users", "Error should mention user requirement")
+		_, err = suite.client.CreateDirectRoom([]string{"@user1:test.matrix.local"}, "Test DM")
+		assert.Error(suite.T(), err, "Should fail DM creation with only one user")
+		assert.Contains(suite.T(), err.Error(), "at least 2 users", "Error should mention user requirement")
 	})
 
-	t.Run("InvalidUserOperations", func(t *testing.T) {
+	suite.Run("InvalidUserOperations", func() {
 		// Test setting display name for non-existent user (should fail)
-		err := client.SetDisplayName("@nonexistent:test.matrix.local", "Test Name")
-		assert.Error(t, err, "Should fail to set display name for non-existent user")
+		err := suite.client.SetDisplayName("@nonexistent:test.matrix.local", "Test Name")
+		assert.Error(suite.T(), err, "Should fail to set display name for non-existent user")
 
 		// Test getting profile for non-existent user
-		profile, err := client.GetUserProfile("@nonexistent:test.matrix.local")
-		require.NoError(t, err, "Should not error for non-existent user profile") // Matrix returns empty profile
-		assert.Empty(t, profile.DisplayName, "Non-existent user should have empty profile")
+		profile, err := suite.client.GetUserProfile("@nonexistent:test.matrix.local")
+		require.NoError(suite.T(), err, "Should not error for non-existent user profile") // Matrix returns empty profile
+		assert.Empty(suite.T(), profile.DisplayName, "Non-existent user should have empty profile")
 	})
 
-	t.Run("InvalidMessageOperations", func(t *testing.T) {
+	suite.Run("InvalidMessageOperations", func() {
 		// Test sending message to non-existent room
 		messageReq := MessageRequest{
 			RoomID:      "!nonexistent:test.matrix.local",
@@ -508,12 +509,12 @@ func TestMatrixClientErrorHandling(t *testing.T) {
 			Message:     "Test message",
 		}
 
-		_, err := client.SendMessage(messageReq)
-		assert.Error(t, err, "Should fail to send message to non-existent room")
+		_, err := suite.client.SendMessage(messageReq)
+		assert.Error(suite.T(), err, "Should fail to send message to non-existent room")
 
 		// Test getting non-existent event
-		_, err = client.GetEvent("!nonexistent:test.matrix.local", "$nonexistent")
-		assert.Error(t, err, "Should fail to get non-existent event")
+		_, err = suite.client.GetEvent("!nonexistent:test.matrix.local", "$nonexistent")
+		assert.Error(suite.T(), err, "Should fail to get non-existent event")
 
 		// Test empty message request
 		emptyReq := MessageRequest{
@@ -522,32 +523,28 @@ func TestMatrixClientErrorHandling(t *testing.T) {
 			// No message content
 		}
 
-		_, err = client.SendMessage(emptyReq)
-		assert.Error(t, err, "Should fail with empty message content")
-		assert.Contains(t, err.Error(), "no message content", "Error should mention missing content")
+		_, err = suite.client.SendMessage(emptyReq)
+		assert.Error(suite.T(), err, "Should fail with empty message content")
+		assert.Contains(suite.T(), err.Error(), "no message content", "Error should mention missing content")
 	})
 
-	t.Run("InvalidMediaOperations", func(t *testing.T) {
-		// Test upload with empty data
-		// Note: Some servers might accept empty files, so we don't assert error here
-		_, _ = client.UploadMedia([]byte{}, "test.txt", "text/plain")
-
+	suite.Run("InvalidMediaOperations", func() {
 		// Test download with invalid MXC URI
-		_, err := client.DownloadFile("invalid-uri", 1024, "")
-		assert.Error(t, err, "Should fail with invalid MXC URI")
-		assert.Contains(t, err.Error(), "invalid Matrix MXC URI", "Error should mention invalid URI")
+		_, err := suite.client.DownloadFile("invalid-uri", 1024, "")
+		assert.Error(suite.T(), err, "Should fail with invalid MXC URI")
+		assert.Contains(suite.T(), err.Error(), "invalid Matrix MXC URI", "Error should mention invalid URI")
 
 		// Test download with malformed MXC URI
-		_, err = client.DownloadFile("mxc://", 1024, "")
-		assert.Error(t, err, "Should fail with malformed MXC URI")
+		_, err = suite.client.DownloadFile("mxc://", 1024, "")
+		assert.Error(suite.T(), err, "Should fail with malformed MXC URI")
 
 		// Test avatar upload with empty data
-		_, err = client.UploadAvatarFromData([]byte{}, "image/png")
-		assert.Error(t, err, "Should fail with empty avatar data")
-		assert.Contains(t, err.Error(), "image data is empty", "Error should mention empty data")
+		_, err = suite.client.UploadAvatarFromData([]byte{}, "image/png")
+		assert.Error(suite.T(), err, "Should fail with empty avatar data")
+		assert.Contains(suite.T(), err.Error(), "image data is empty", "Error should mention empty data")
 	})
 
-	t.Run("ParameterValidation", func(t *testing.T) {
+	suite.Run("ParameterValidation", func() {
 		// Test required parameter validation
 		messageReq := MessageRequest{
 			// Missing RoomID
@@ -555,77 +552,64 @@ func TestMatrixClientErrorHandling(t *testing.T) {
 			Message:     "Test",
 		}
 
-		_, err := client.SendMessage(messageReq)
-		assert.Error(t, err, "Should fail with missing room ID")
-		assert.Contains(t, err.Error(), "room_id is required", "Error should mention room ID")
+		_, err := suite.client.SendMessage(messageReq)
+		assert.Error(suite.T(), err, "Should fail with missing room ID")
+		assert.Contains(suite.T(), err.Error(), "room_id is required", "Error should mention room ID")
 
 		messageReq.RoomID = "!test:test.matrix.local"
 		messageReq.GhostUserID = "" // Missing ghost user ID
 
-		_, err = client.SendMessage(messageReq)
-		assert.Error(t, err, "Should fail with missing ghost user ID")
-		assert.Contains(t, err.Error(), "ghost_user_id is required", "Error should mention ghost user ID")
+		_, err = suite.client.SendMessage(messageReq)
+		assert.Error(suite.T(), err, "Should fail with missing ghost user ID")
+		assert.Contains(suite.T(), err.Error(), "ghost_user_id is required", "Error should mention ghost user ID")
 	})
 
-	t.Run("NetworkErrorHandling", func(t *testing.T) {
+	suite.Run("NetworkErrorHandling", func() {
 		// Test with client pointing to a port that definitely doesn't exist
 		networkFailClient := NewClientWithLogger(
 			"http://localhost:99999", // Port that should be unused
-			matrixContainer.ASToken,
+			suite.matrixContainer.ASToken,
 			"test-remote-id",
-			NewTestLogger(t),
+			NewTestLogger(suite.T()),
 		)
 
 		// All operations should fail with network errors
 		err := networkFailClient.TestConnection()
-		assert.Error(t, err, "Should fail with network error")
+		assert.Error(suite.T(), err, "Should fail with network error")
 
 		_, err = networkFailClient.CreateRoom("Test", "Test", "test.local", false, "test")
-		assert.Error(t, err, "Should fail with network error")
+		assert.Error(suite.T(), err, "Should fail with network error")
 
 		_, err = networkFailClient.GetServerInfo()
-		assert.Error(t, err, "Should fail with network error")
+		assert.Error(suite.T(), err, "Should fail with network error")
 	})
 }
 
 // TestMatrixClientWithFiles tests file attachment handling
-func TestMatrixClientWithFiles(t *testing.T) {
-	// Start Matrix test container
-	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
-	defer matrixContainer.Cleanup(t)
-
-	// Create Matrix client
-	client := NewClientWithLogger(
-		matrixContainer.ServerURL,
-		matrixContainer.ASToken,
-		"test-remote-id",
-		NewTestLogger(t),
-	)
-	client.SetServerDomain(matrixContainer.ServerDomain)
-
+func (suite *MatrixClientTestSuite) TestMatrixClientWithFiles() {
 	// Create test room and user
-	roomIdentifier, err := client.CreateRoom("File Test Room", "Testing file attachments", matrixContainer.ServerDomain, false, "test-file-channel")
-	require.NoError(t, err, "Should create room for file tests")
+	roomIdentifier, err := suite.client.CreateRoom("File Test Room", "Testing file attachments", suite.matrixContainer.ServerDomain, false, "test-file-channel")
+	require.NoError(suite.T(), err, "Should create room for file tests")
 
-	roomID, err := client.ResolveRoomAlias(roomIdentifier)
-	require.NoError(t, err, "Should resolve room identifier")
+	roomID, err := suite.client.ResolveRoomAlias(roomIdentifier)
+	require.NoError(suite.T(), err, "Should resolve room identifier")
 
-	ghostUser, err := client.CreateGhostUser("test-file-user", "File Test User", nil, "")
-	require.NoError(t, err, "Should create ghost user for file tests")
+	ghostUser, err := suite.client.CreateGhostUser("test-file-user", "File Test User", nil, "")
+	require.NoError(suite.T(), err, "Should create ghost user for file tests")
 
-	err = client.JoinRoomAsUser(roomID, ghostUser.UserID)
-	require.NoError(t, err, "Should join ghost user to room")
+	err = suite.client.JoinRoomAsUser(roomID, ghostUser.UserID)
+	require.NoError(suite.T(), err, "Should join ghost user to room")
 
-	t.Run("SendMessageWithFiles", func(t *testing.T) {
+	suite.Run("SendMessageWithFiles", func() {
 		// Upload test files first
 		testFileData := []byte("This is a test file content for attachment testing")
 		testImageData := []byte("fake-image-data-for-testing")
 
-		fileMxcURI, err := client.UploadMedia(testFileData, "test-document.txt", "text/plain")
-		require.NoError(t, err, "Should upload test file")
+		fileMxcURI, err := suite.client.UploadMedia(testFileData, "test-document.txt", "text/plain")
+		require.NoError(suite.T(), err, "Should upload test file")
 
-		imageMxcURI, err := client.UploadMedia(testImageData, "test-image.png", "image/png")
-		require.NoError(t, err, "Should upload test image")
+		imageMxcURI, err := suite.client.UploadMedia(testImageData, "test-image.png", "image/png")
+		require.NoError(suite.T(), err, "Should upload test image")
 
 		// Send message with file attachments
 		messageReq := MessageRequest{
@@ -649,25 +633,25 @@ func TestMatrixClientWithFiles(t *testing.T) {
 			},
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send message with files")
-		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send message with files")
+		assert.NotEmpty(suite.T(), response.EventID, "Event ID should not be empty")
 
 		// Verify we can download the files back
-		downloadedFile, err := client.DownloadFile(fileMxcURI, int64(len(testFileData)*2), "text/")
-		require.NoError(t, err, "Should download file")
-		assert.Equal(t, testFileData, downloadedFile, "Downloaded file should match uploaded data")
+		downloadedFile, err := suite.client.DownloadFile(fileMxcURI, int64(len(testFileData)*2), "text/")
+		require.NoError(suite.T(), err, "Should download file")
+		assert.Equal(suite.T(), testFileData, downloadedFile, "Downloaded file should match uploaded data")
 
-		downloadedImage, err := client.DownloadFile(imageMxcURI, int64(len(testImageData)*2), "image/")
-		require.NoError(t, err, "Should download image")
-		assert.Equal(t, testImageData, downloadedImage, "Downloaded image should match uploaded data")
+		downloadedImage, err := suite.client.DownloadFile(imageMxcURI, int64(len(testImageData)*2), "image/")
+		require.NoError(suite.T(), err, "Should download image")
+		assert.Equal(suite.T(), testImageData, downloadedImage, "Downloaded image should match uploaded data")
 	})
 
-	t.Run("SendOnlyFiles", func(t *testing.T) {
+	suite.Run("SendOnlyFiles", func() {
 		// Upload test file
 		testData := []byte("File-only message test content")
-		mxcURI, err := client.UploadMedia(testData, "file-only.txt", "text/plain")
-		require.NoError(t, err, "Should upload test file")
+		mxcURI, err := suite.client.UploadMedia(testData, "file-only.txt", "text/plain")
+		require.NoError(suite.T(), err, "Should upload test file")
 
 		// Send message with only files (no text)
 		messageReq := MessageRequest{
@@ -685,8 +669,13 @@ func TestMatrixClientWithFiles(t *testing.T) {
 			},
 		}
 
-		response, err := client.SendMessage(messageReq)
-		require.NoError(t, err, "Should send file-only message")
-		assert.NotEmpty(t, response.EventID, "Event ID should not be empty")
+		response, err := suite.client.SendMessage(messageReq)
+		require.NoError(suite.T(), err, "Should send file-only message")
+		assert.NotEmpty(suite.T(), response.EventID, "Event ID should not be empty")
 	})
+}
+
+// Test runner functions to connect the suite to Go's testing framework
+func TestMatrixClientTestSuite(t *testing.T) {
+	suite.Run(t, new(MatrixClientTestSuite))
 }

--- a/server/migrations_test.go
+++ b/server/migrations_test.go
@@ -113,7 +113,7 @@ func TestMigrateUserMappings(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run user migration
-		err = plugin.migrateUserMappings()
+		_, err = plugin.migrateUserMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Check that reverse mappings were created
@@ -151,7 +151,7 @@ func TestMigrateUserMappings(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run migration
-		err = plugin.migrateUserMappings()
+		_, err = plugin.migrateUserMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Incorrect reverse mapping should be corrected based on forward mapping
@@ -182,7 +182,7 @@ func TestMigrateUserMappings(t *testing.T) {
 		}
 
 		// Run migration
-		err := plugin.migrateUserMappings()
+		_, err := plugin.migrateUserMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Verify all reverse mappings were created
@@ -217,7 +217,7 @@ func TestMigrateChannelMappings(t *testing.T) {
 		}
 
 		// Run channel migration
-		err := plugin.migrateChannelMappings()
+		_, err := plugin.migrateChannelMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Check that reverse mappings were created
@@ -245,7 +245,7 @@ func TestMigrateChannelMappings(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run channel migration
-		err = plugin.migrateChannelMappings()
+		_, err = plugin.migrateChannelMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Check that alias reverse mapping was created (even without Matrix client)
@@ -270,7 +270,7 @@ func TestMigrateChannelMappings(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run channel migration - should not fail even if alias resolution fails
-		err = plugin.migrateChannelMappings()
+		_, err = plugin.migrateChannelMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Check that alias reverse mapping was created
@@ -296,7 +296,7 @@ func TestMigrateChannelMappings(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run migration
-		err = plugin.migrateChannelMappings()
+		_, err = plugin.migrateChannelMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Incorrect reverse mapping should be corrected based on forward mapping
@@ -320,7 +320,7 @@ func TestMigrateChannelMappings(t *testing.T) {
 		}
 
 		// Run migration
-		err := plugin.migrateChannelMappings()
+		_, err := plugin.migrateChannelMappingsWithResults()
 		assert.NoError(t, err)
 
 		// Verify all reverse mappings were created

--- a/server/mocks/mock_kvstore.go
+++ b/server/mocks/mock_kvstore.go
@@ -42,7 +42,7 @@ func (m *MockKVStore) Delete(arg0 string) error {
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockKVStoreMockRecorder) Delete(arg0 any) *gomock.Call {
+func (mr *MockKVStoreMockRecorder) Delete(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKVStore)(nil).Delete), arg0)
 }
@@ -57,7 +57,7 @@ func (m *MockKVStore) Get(arg0 string) ([]byte, error) {
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockKVStoreMockRecorder) Get(arg0 any) *gomock.Call {
+func (mr *MockKVStoreMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockKVStore)(nil).Get), arg0)
 }
@@ -72,7 +72,7 @@ func (m *MockKVStore) GetTemplateData(arg0 string) (string, error) {
 }
 
 // GetTemplateData indicates an expected call of GetTemplateData.
-func (mr *MockKVStoreMockRecorder) GetTemplateData(arg0 any) *gomock.Call {
+func (mr *MockKVStoreMockRecorder) GetTemplateData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateData", reflect.TypeOf((*MockKVStore)(nil).GetTemplateData), arg0)
 }
@@ -87,9 +87,24 @@ func (m *MockKVStore) ListKeys(arg0, arg1 int) ([]string, error) {
 }
 
 // ListKeys indicates an expected call of ListKeys.
-func (mr *MockKVStoreMockRecorder) ListKeys(arg0, arg1 any) *gomock.Call {
+func (mr *MockKVStoreMockRecorder) ListKeys(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeys", reflect.TypeOf((*MockKVStore)(nil).ListKeys), arg0, arg1)
+}
+
+// ListKeysWithPrefix mocks base method.
+func (m *MockKVStore) ListKeysWithPrefix(arg0, arg1 int, arg2 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListKeysWithPrefix", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListKeysWithPrefix indicates an expected call of ListKeysWithPrefix.
+func (mr *MockKVStoreMockRecorder) ListKeysWithPrefix(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeysWithPrefix", reflect.TypeOf((*MockKVStore)(nil).ListKeysWithPrefix), arg0, arg1, arg2)
 }
 
 // Set mocks base method.
@@ -101,7 +116,7 @@ func (m *MockKVStore) Set(arg0 string, arg1 []byte) error {
 }
 
 // Set indicates an expected call of Set.
-func (mr *MockKVStoreMockRecorder) Set(arg0, arg1 any) *gomock.Call {
+func (mr *MockKVStoreMockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockKVStore)(nil).Set), arg0, arg1)
 }

--- a/server/mocks/mock_plugin_api.go
+++ b/server/mocks/mock_plugin_api.go
@@ -46,7 +46,7 @@ func (m *MockAPI) AddChannelMember(arg0, arg1 string) (*model.ChannelMember, *mo
 }
 
 // AddChannelMember indicates an expected call of AddChannelMember.
-func (mr *MockAPIMockRecorder) AddChannelMember(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) AddChannelMember(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddChannelMember", reflect.TypeOf((*MockAPI)(nil).AddChannelMember), arg0, arg1)
 }
@@ -61,7 +61,7 @@ func (m *MockAPI) AddReaction(arg0 *model.Reaction) (*model.Reaction, *model.App
 }
 
 // AddReaction indicates an expected call of AddReaction.
-func (mr *MockAPIMockRecorder) AddReaction(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) AddReaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReaction", reflect.TypeOf((*MockAPI)(nil).AddReaction), arg0)
 }
@@ -76,7 +76,7 @@ func (m *MockAPI) AddUserToChannel(arg0, arg1, arg2 string) (*model.ChannelMembe
 }
 
 // AddUserToChannel indicates an expected call of AddUserToChannel.
-func (mr *MockAPIMockRecorder) AddUserToChannel(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) AddUserToChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToChannel", reflect.TypeOf((*MockAPI)(nil).AddUserToChannel), arg0, arg1, arg2)
 }
@@ -91,7 +91,7 @@ func (m *MockAPI) CopyFileInfos(arg0 string, arg1 []string) ([]string, *model.Ap
 }
 
 // CopyFileInfos indicates an expected call of CopyFileInfos.
-func (mr *MockAPIMockRecorder) CopyFileInfos(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CopyFileInfos(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyFileInfos", reflect.TypeOf((*MockAPI)(nil).CopyFileInfos), arg0, arg1)
 }
@@ -106,7 +106,7 @@ func (m *MockAPI) CreateBot(arg0 *model.Bot) (*model.Bot, *model.AppError) {
 }
 
 // CreateBot indicates an expected call of CreateBot.
-func (mr *MockAPIMockRecorder) CreateBot(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateBot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBot", reflect.TypeOf((*MockAPI)(nil).CreateBot), arg0)
 }
@@ -121,7 +121,7 @@ func (m *MockAPI) CreateChannel(arg0 *model.Channel) (*model.Channel, *model.App
 }
 
 // CreateChannel indicates an expected call of CreateChannel.
-func (mr *MockAPIMockRecorder) CreateChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannel", reflect.TypeOf((*MockAPI)(nil).CreateChannel), arg0)
 }
@@ -136,7 +136,7 @@ func (m *MockAPI) CreateChannelSidebarCategory(arg0, arg1 string, arg2 *model.Si
 }
 
 // CreateChannelSidebarCategory indicates an expected call of CreateChannelSidebarCategory.
-func (mr *MockAPIMockRecorder) CreateChannelSidebarCategory(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateChannelSidebarCategory(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChannelSidebarCategory", reflect.TypeOf((*MockAPI)(nil).CreateChannelSidebarCategory), arg0, arg1, arg2)
 }
@@ -151,7 +151,7 @@ func (m *MockAPI) CreateCommand(arg0 *model.Command) (*model.Command, error) {
 }
 
 // CreateCommand indicates an expected call of CreateCommand.
-func (mr *MockAPIMockRecorder) CreateCommand(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCommand", reflect.TypeOf((*MockAPI)(nil).CreateCommand), arg0)
 }
@@ -166,7 +166,7 @@ func (m *MockAPI) CreateOAuthApp(arg0 *model.OAuthApp) (*model.OAuthApp, *model.
 }
 
 // CreateOAuthApp indicates an expected call of CreateOAuthApp.
-func (mr *MockAPIMockRecorder) CreateOAuthApp(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateOAuthApp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOAuthApp", reflect.TypeOf((*MockAPI)(nil).CreateOAuthApp), arg0)
 }
@@ -181,7 +181,7 @@ func (m *MockAPI) CreatePost(arg0 *model.Post) (*model.Post, *model.AppError) {
 }
 
 // CreatePost indicates an expected call of CreatePost.
-func (mr *MockAPIMockRecorder) CreatePost(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreatePost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePost", reflect.TypeOf((*MockAPI)(nil).CreatePost), arg0)
 }
@@ -196,7 +196,7 @@ func (m *MockAPI) CreateSession(arg0 *model.Session) (*model.Session, *model.App
 }
 
 // CreateSession indicates an expected call of CreateSession.
-func (mr *MockAPIMockRecorder) CreateSession(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockAPI)(nil).CreateSession), arg0)
 }
@@ -211,7 +211,7 @@ func (m *MockAPI) CreateTeam(arg0 *model.Team) (*model.Team, *model.AppError) {
 }
 
 // CreateTeam indicates an expected call of CreateTeam.
-func (mr *MockAPIMockRecorder) CreateTeam(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateTeam(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeam", reflect.TypeOf((*MockAPI)(nil).CreateTeam), arg0)
 }
@@ -226,7 +226,7 @@ func (m *MockAPI) CreateTeamMember(arg0, arg1 string) (*model.TeamMember, *model
 }
 
 // CreateTeamMember indicates an expected call of CreateTeamMember.
-func (mr *MockAPIMockRecorder) CreateTeamMember(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateTeamMember(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamMember", reflect.TypeOf((*MockAPI)(nil).CreateTeamMember), arg0, arg1)
 }
@@ -241,7 +241,7 @@ func (m *MockAPI) CreateTeamMembers(arg0 string, arg1 []string, arg2 string) ([]
 }
 
 // CreateTeamMembers indicates an expected call of CreateTeamMembers.
-func (mr *MockAPIMockRecorder) CreateTeamMembers(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateTeamMembers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamMembers", reflect.TypeOf((*MockAPI)(nil).CreateTeamMembers), arg0, arg1, arg2)
 }
@@ -256,7 +256,7 @@ func (m *MockAPI) CreateTeamMembersGracefully(arg0 string, arg1 []string, arg2 s
 }
 
 // CreateTeamMembersGracefully indicates an expected call of CreateTeamMembersGracefully.
-func (mr *MockAPIMockRecorder) CreateTeamMembersGracefully(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateTeamMembersGracefully(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamMembersGracefully", reflect.TypeOf((*MockAPI)(nil).CreateTeamMembersGracefully), arg0, arg1, arg2)
 }
@@ -271,7 +271,7 @@ func (m *MockAPI) CreateUploadSession(arg0 *model.UploadSession) (*model.UploadS
 }
 
 // CreateUploadSession indicates an expected call of CreateUploadSession.
-func (mr *MockAPIMockRecorder) CreateUploadSession(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateUploadSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUploadSession", reflect.TypeOf((*MockAPI)(nil).CreateUploadSession), arg0)
 }
@@ -286,7 +286,7 @@ func (m *MockAPI) CreateUser(arg0 *model.User) (*model.User, *model.AppError) {
 }
 
 // CreateUser indicates an expected call of CreateUser.
-func (mr *MockAPIMockRecorder) CreateUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockAPI)(nil).CreateUser), arg0)
 }
@@ -301,7 +301,7 @@ func (m *MockAPI) CreateUserAccessToken(arg0 *model.UserAccessToken) (*model.Use
 }
 
 // CreateUserAccessToken indicates an expected call of CreateUserAccessToken.
-func (mr *MockAPIMockRecorder) CreateUserAccessToken(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) CreateUserAccessToken(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserAccessToken", reflect.TypeOf((*MockAPI)(nil).CreateUserAccessToken), arg0)
 }
@@ -315,7 +315,7 @@ func (m *MockAPI) DeleteChannel(arg0 string) *model.AppError {
 }
 
 // DeleteChannel indicates an expected call of DeleteChannel.
-func (mr *MockAPIMockRecorder) DeleteChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChannel", reflect.TypeOf((*MockAPI)(nil).DeleteChannel), arg0)
 }
@@ -329,7 +329,7 @@ func (m *MockAPI) DeleteChannelMember(arg0, arg1 string) *model.AppError {
 }
 
 // DeleteChannelMember indicates an expected call of DeleteChannelMember.
-func (mr *MockAPIMockRecorder) DeleteChannelMember(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteChannelMember(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChannelMember", reflect.TypeOf((*MockAPI)(nil).DeleteChannelMember), arg0, arg1)
 }
@@ -343,7 +343,7 @@ func (m *MockAPI) DeleteCommand(arg0 string) error {
 }
 
 // DeleteCommand indicates an expected call of DeleteCommand.
-func (mr *MockAPIMockRecorder) DeleteCommand(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCommand", reflect.TypeOf((*MockAPI)(nil).DeleteCommand), arg0)
 }
@@ -355,7 +355,7 @@ func (m *MockAPI) DeleteEphemeralPost(arg0, arg1 string) {
 }
 
 // DeleteEphemeralPost indicates an expected call of DeleteEphemeralPost.
-func (mr *MockAPIMockRecorder) DeleteEphemeralPost(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteEphemeralPost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEphemeralPost", reflect.TypeOf((*MockAPI)(nil).DeleteEphemeralPost), arg0, arg1)
 }
@@ -369,7 +369,7 @@ func (m *MockAPI) DeleteOAuthApp(arg0 string) *model.AppError {
 }
 
 // DeleteOAuthApp indicates an expected call of DeleteOAuthApp.
-func (mr *MockAPIMockRecorder) DeleteOAuthApp(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteOAuthApp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOAuthApp", reflect.TypeOf((*MockAPI)(nil).DeleteOAuthApp), arg0)
 }
@@ -383,7 +383,7 @@ func (m *MockAPI) DeletePost(arg0 string) *model.AppError {
 }
 
 // DeletePost indicates an expected call of DeletePost.
-func (mr *MockAPIMockRecorder) DeletePost(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeletePost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePost", reflect.TypeOf((*MockAPI)(nil).DeletePost), arg0)
 }
@@ -397,7 +397,7 @@ func (m *MockAPI) DeletePreferencesForUser(arg0 string, arg1 []model.Preference)
 }
 
 // DeletePreferencesForUser indicates an expected call of DeletePreferencesForUser.
-func (mr *MockAPIMockRecorder) DeletePreferencesForUser(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeletePreferencesForUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePreferencesForUser", reflect.TypeOf((*MockAPI)(nil).DeletePreferencesForUser), arg0, arg1)
 }
@@ -411,7 +411,7 @@ func (m *MockAPI) DeleteTeam(arg0 string) *model.AppError {
 }
 
 // DeleteTeam indicates an expected call of DeleteTeam.
-func (mr *MockAPIMockRecorder) DeleteTeam(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteTeam(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTeam", reflect.TypeOf((*MockAPI)(nil).DeleteTeam), arg0)
 }
@@ -425,7 +425,7 @@ func (m *MockAPI) DeleteTeamMember(arg0, arg1, arg2 string) *model.AppError {
 }
 
 // DeleteTeamMember indicates an expected call of DeleteTeamMember.
-func (mr *MockAPIMockRecorder) DeleteTeamMember(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteTeamMember(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTeamMember", reflect.TypeOf((*MockAPI)(nil).DeleteTeamMember), arg0, arg1, arg2)
 }
@@ -439,7 +439,7 @@ func (m *MockAPI) DeleteUser(arg0 string) *model.AppError {
 }
 
 // DeleteUser indicates an expected call of DeleteUser.
-func (mr *MockAPIMockRecorder) DeleteUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockAPI)(nil).DeleteUser), arg0)
 }
@@ -453,7 +453,7 @@ func (m *MockAPI) DisablePlugin(arg0 string) *model.AppError {
 }
 
 // DisablePlugin indicates an expected call of DisablePlugin.
-func (mr *MockAPIMockRecorder) DisablePlugin(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DisablePlugin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisablePlugin", reflect.TypeOf((*MockAPI)(nil).DisablePlugin), arg0)
 }
@@ -467,7 +467,7 @@ func (m *MockAPI) EnablePlugin(arg0 string) *model.AppError {
 }
 
 // EnablePlugin indicates an expected call of EnablePlugin.
-func (mr *MockAPIMockRecorder) EnablePlugin(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) EnablePlugin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePlugin", reflect.TypeOf((*MockAPI)(nil).EnablePlugin), arg0)
 }
@@ -482,7 +482,7 @@ func (m *MockAPI) EnsureBotUser(arg0 *model.Bot) (string, error) {
 }
 
 // EnsureBotUser indicates an expected call of EnsureBotUser.
-func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBotUser", reflect.TypeOf((*MockAPI)(nil).EnsureBotUser), arg0)
 }
@@ -497,7 +497,7 @@ func (m *MockAPI) ExecuteSlashCommand(arg0 *model.CommandArgs) (*model.CommandRe
 }
 
 // ExecuteSlashCommand indicates an expected call of ExecuteSlashCommand.
-func (mr *MockAPIMockRecorder) ExecuteSlashCommand(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ExecuteSlashCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteSlashCommand", reflect.TypeOf((*MockAPI)(nil).ExecuteSlashCommand), arg0)
 }
@@ -511,7 +511,7 @@ func (m *MockAPI) ExtendSessionExpiry(arg0 string, arg1 int64) *model.AppError {
 }
 
 // ExtendSessionExpiry indicates an expected call of ExtendSessionExpiry.
-func (mr *MockAPIMockRecorder) ExtendSessionExpiry(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ExtendSessionExpiry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendSessionExpiry", reflect.TypeOf((*MockAPI)(nil).ExtendSessionExpiry), arg0, arg1)
 }
@@ -526,7 +526,7 @@ func (m *MockAPI) GetBot(arg0 string, arg1 bool) (*model.Bot, *model.AppError) {
 }
 
 // GetBot indicates an expected call of GetBot.
-func (mr *MockAPIMockRecorder) GetBot(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetBot(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBot", reflect.TypeOf((*MockAPI)(nil).GetBot), arg0, arg1)
 }
@@ -541,7 +541,7 @@ func (m *MockAPI) GetBots(arg0 *model.BotGetOptions) ([]*model.Bot, *model.AppEr
 }
 
 // GetBots indicates an expected call of GetBots.
-func (mr *MockAPIMockRecorder) GetBots(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetBots(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBots", reflect.TypeOf((*MockAPI)(nil).GetBots), arg0)
 }
@@ -571,7 +571,7 @@ func (m *MockAPI) GetChannel(arg0 string) (*model.Channel, *model.AppError) {
 }
 
 // GetChannel indicates an expected call of GetChannel.
-func (mr *MockAPIMockRecorder) GetChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannel", reflect.TypeOf((*MockAPI)(nil).GetChannel), arg0)
 }
@@ -586,7 +586,7 @@ func (m *MockAPI) GetChannelByName(arg0, arg1 string, arg2 bool) (*model.Channel
 }
 
 // GetChannelByName indicates an expected call of GetChannelByName.
-func (mr *MockAPIMockRecorder) GetChannelByName(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelByName(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelByName", reflect.TypeOf((*MockAPI)(nil).GetChannelByName), arg0, arg1, arg2)
 }
@@ -601,7 +601,7 @@ func (m *MockAPI) GetChannelByNameForTeamName(arg0, arg1 string, arg2 bool) (*mo
 }
 
 // GetChannelByNameForTeamName indicates an expected call of GetChannelByNameForTeamName.
-func (mr *MockAPIMockRecorder) GetChannelByNameForTeamName(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelByNameForTeamName(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelByNameForTeamName", reflect.TypeOf((*MockAPI)(nil).GetChannelByNameForTeamName), arg0, arg1, arg2)
 }
@@ -616,7 +616,7 @@ func (m *MockAPI) GetChannelMember(arg0, arg1 string) (*model.ChannelMember, *mo
 }
 
 // GetChannelMember indicates an expected call of GetChannelMember.
-func (mr *MockAPIMockRecorder) GetChannelMember(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelMember(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelMember", reflect.TypeOf((*MockAPI)(nil).GetChannelMember), arg0, arg1)
 }
@@ -631,7 +631,7 @@ func (m *MockAPI) GetChannelMembers(arg0 string, arg1, arg2 int) (model.ChannelM
 }
 
 // GetChannelMembers indicates an expected call of GetChannelMembers.
-func (mr *MockAPIMockRecorder) GetChannelMembers(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelMembers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelMembers", reflect.TypeOf((*MockAPI)(nil).GetChannelMembers), arg0, arg1, arg2)
 }
@@ -646,7 +646,7 @@ func (m *MockAPI) GetChannelMembersByIds(arg0 string, arg1 []string) (model.Chan
 }
 
 // GetChannelMembersByIds indicates an expected call of GetChannelMembersByIds.
-func (mr *MockAPIMockRecorder) GetChannelMembersByIds(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelMembersByIds(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelMembersByIds", reflect.TypeOf((*MockAPI)(nil).GetChannelMembersByIds), arg0, arg1)
 }
@@ -661,7 +661,7 @@ func (m *MockAPI) GetChannelMembersForUser(arg0, arg1 string, arg2, arg3 int) ([
 }
 
 // GetChannelMembersForUser indicates an expected call of GetChannelMembersForUser.
-func (mr *MockAPIMockRecorder) GetChannelMembersForUser(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelMembersForUser(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelMembersForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelMembersForUser), arg0, arg1, arg2, arg3)
 }
@@ -676,7 +676,7 @@ func (m *MockAPI) GetChannelSidebarCategories(arg0, arg1 string) (*model.Ordered
 }
 
 // GetChannelSidebarCategories indicates an expected call of GetChannelSidebarCategories.
-func (mr *MockAPIMockRecorder) GetChannelSidebarCategories(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelSidebarCategories(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelSidebarCategories", reflect.TypeOf((*MockAPI)(nil).GetChannelSidebarCategories), arg0, arg1)
 }
@@ -691,7 +691,7 @@ func (m *MockAPI) GetChannelStats(arg0 string) (*model.ChannelStats, *model.AppE
 }
 
 // GetChannelStats indicates an expected call of GetChannelStats.
-func (mr *MockAPIMockRecorder) GetChannelStats(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelStats(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelStats", reflect.TypeOf((*MockAPI)(nil).GetChannelStats), arg0)
 }
@@ -706,7 +706,7 @@ func (m *MockAPI) GetChannelsForTeamForUser(arg0, arg1 string, arg2 bool) ([]*mo
 }
 
 // GetChannelsForTeamForUser indicates an expected call of GetChannelsForTeamForUser.
-func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelsForTeamForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelsForTeamForUser), arg0, arg1, arg2)
 }
@@ -736,7 +736,7 @@ func (m *MockAPI) GetCommand(arg0 string) (*model.Command, error) {
 }
 
 // GetCommand indicates an expected call of GetCommand.
-func (mr *MockAPIMockRecorder) GetCommand(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommand", reflect.TypeOf((*MockAPI)(nil).GetCommand), arg0)
 }
@@ -779,7 +779,7 @@ func (m *MockAPI) GetDirectChannel(arg0, arg1 string) (*model.Channel, *model.Ap
 }
 
 // GetDirectChannel indicates an expected call of GetDirectChannel.
-func (mr *MockAPIMockRecorder) GetDirectChannel(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetDirectChannel(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectChannel", reflect.TypeOf((*MockAPI)(nil).GetDirectChannel), arg0, arg1)
 }
@@ -794,7 +794,7 @@ func (m *MockAPI) GetEmoji(arg0 string) (*model.Emoji, *model.AppError) {
 }
 
 // GetEmoji indicates an expected call of GetEmoji.
-func (mr *MockAPIMockRecorder) GetEmoji(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetEmoji(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmoji", reflect.TypeOf((*MockAPI)(nil).GetEmoji), arg0)
 }
@@ -809,7 +809,7 @@ func (m *MockAPI) GetEmojiByName(arg0 string) (*model.Emoji, *model.AppError) {
 }
 
 // GetEmojiByName indicates an expected call of GetEmojiByName.
-func (mr *MockAPIMockRecorder) GetEmojiByName(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetEmojiByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmojiByName", reflect.TypeOf((*MockAPI)(nil).GetEmojiByName), arg0)
 }
@@ -825,7 +825,7 @@ func (m *MockAPI) GetEmojiImage(arg0 string) ([]byte, string, *model.AppError) {
 }
 
 // GetEmojiImage indicates an expected call of GetEmojiImage.
-func (mr *MockAPIMockRecorder) GetEmojiImage(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetEmojiImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmojiImage", reflect.TypeOf((*MockAPI)(nil).GetEmojiImage), arg0)
 }
@@ -840,7 +840,7 @@ func (m *MockAPI) GetEmojiList(arg0 string, arg1, arg2 int) ([]*model.Emoji, *mo
 }
 
 // GetEmojiList indicates an expected call of GetEmojiList.
-func (mr *MockAPIMockRecorder) GetEmojiList(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetEmojiList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEmojiList", reflect.TypeOf((*MockAPI)(nil).GetEmojiList), arg0, arg1, arg2)
 }
@@ -855,7 +855,7 @@ func (m *MockAPI) GetFile(arg0 string) ([]byte, *model.AppError) {
 }
 
 // GetFile indicates an expected call of GetFile.
-func (mr *MockAPIMockRecorder) GetFile(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockAPI)(nil).GetFile), arg0)
 }
@@ -870,7 +870,7 @@ func (m *MockAPI) GetFileInfo(arg0 string) (*model.FileInfo, *model.AppError) {
 }
 
 // GetFileInfo indicates an expected call of GetFileInfo.
-func (mr *MockAPIMockRecorder) GetFileInfo(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFileInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileInfo", reflect.TypeOf((*MockAPI)(nil).GetFileInfo), arg0)
 }
@@ -885,7 +885,7 @@ func (m *MockAPI) GetFileInfos(arg0, arg1 int, arg2 *model.GetFileInfosOptions) 
 }
 
 // GetFileInfos indicates an expected call of GetFileInfos.
-func (mr *MockAPIMockRecorder) GetFileInfos(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFileInfos(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileInfos", reflect.TypeOf((*MockAPI)(nil).GetFileInfos), arg0, arg1, arg2)
 }
@@ -900,7 +900,7 @@ func (m *MockAPI) GetFileLink(arg0 string) (string, *model.AppError) {
 }
 
 // GetFileLink indicates an expected call of GetFileLink.
-func (mr *MockAPIMockRecorder) GetFileLink(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetFileLink(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileLink", reflect.TypeOf((*MockAPI)(nil).GetFileLink), arg0)
 }
@@ -915,7 +915,7 @@ func (m *MockAPI) GetGroup(arg0 string) (*model.Group, *model.AppError) {
 }
 
 // GetGroup indicates an expected call of GetGroup.
-func (mr *MockAPIMockRecorder) GetGroup(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockAPI)(nil).GetGroup), arg0)
 }
@@ -930,7 +930,7 @@ func (m *MockAPI) GetGroupByName(arg0 string) (*model.Group, *model.AppError) {
 }
 
 // GetGroupByName indicates an expected call of GetGroupByName.
-func (mr *MockAPIMockRecorder) GetGroupByName(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroupByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupByName", reflect.TypeOf((*MockAPI)(nil).GetGroupByName), arg0)
 }
@@ -945,7 +945,7 @@ func (m *MockAPI) GetGroupChannel(arg0 []string) (*model.Channel, *model.AppErro
 }
 
 // GetGroupChannel indicates an expected call of GetGroupChannel.
-func (mr *MockAPIMockRecorder) GetGroupChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroupChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupChannel", reflect.TypeOf((*MockAPI)(nil).GetGroupChannel), arg0)
 }
@@ -960,7 +960,7 @@ func (m *MockAPI) GetGroupMemberUsers(arg0 string, arg1, arg2 int) ([]*model.Use
 }
 
 // GetGroupMemberUsers indicates an expected call of GetGroupMemberUsers.
-func (mr *MockAPIMockRecorder) GetGroupMemberUsers(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroupMemberUsers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupMemberUsers", reflect.TypeOf((*MockAPI)(nil).GetGroupMemberUsers), arg0, arg1, arg2)
 }
@@ -975,7 +975,7 @@ func (m *MockAPI) GetGroupsBySource(arg0 model.GroupSource) ([]*model.Group, *mo
 }
 
 // GetGroupsBySource indicates an expected call of GetGroupsBySource.
-func (mr *MockAPIMockRecorder) GetGroupsBySource(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroupsBySource(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsBySource", reflect.TypeOf((*MockAPI)(nil).GetGroupsBySource), arg0)
 }
@@ -990,7 +990,7 @@ func (m *MockAPI) GetGroupsForUser(arg0 string) ([]*model.Group, *model.AppError
 }
 
 // GetGroupsForUser indicates an expected call of GetGroupsForUser.
-func (mr *MockAPIMockRecorder) GetGroupsForUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetGroupsForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupsForUser", reflect.TypeOf((*MockAPI)(nil).GetGroupsForUser), arg0)
 }
@@ -1005,7 +1005,7 @@ func (m *MockAPI) GetLDAPUserAttributes(arg0 string, arg1 []string) (map[string]
 }
 
 // GetLDAPUserAttributes indicates an expected call of GetLDAPUserAttributes.
-func (mr *MockAPIMockRecorder) GetLDAPUserAttributes(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetLDAPUserAttributes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLDAPUserAttributes", reflect.TypeOf((*MockAPI)(nil).GetLDAPUserAttributes), arg0, arg1)
 }
@@ -1034,16 +1034,16 @@ func (m *MockAPI) GetOAuthApp(arg0 string) (*model.OAuthApp, *model.AppError) {
 }
 
 // GetOAuthApp indicates an expected call of GetOAuthApp.
-func (mr *MockAPIMockRecorder) GetOAuthApp(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetOAuthApp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOAuthApp", reflect.TypeOf((*MockAPI)(nil).GetOAuthApp), arg0)
 }
 
 // GetPluginConfig mocks base method.
-func (m *MockAPI) GetPluginConfig() map[string]any {
+func (m *MockAPI) GetPluginConfig() map[string]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPluginConfig")
-	ret0, _ := ret[0].(map[string]any)
+	ret0, _ := ret[0].(map[string]interface{})
 	return ret0
 }
 
@@ -1077,7 +1077,7 @@ func (m *MockAPI) GetPluginStatus(arg0 string) (*model.PluginStatus, *model.AppE
 }
 
 // GetPluginStatus indicates an expected call of GetPluginStatus.
-func (mr *MockAPIMockRecorder) GetPluginStatus(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPluginStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPluginStatus", reflect.TypeOf((*MockAPI)(nil).GetPluginStatus), arg0)
 }
@@ -1107,7 +1107,7 @@ func (m *MockAPI) GetPost(arg0 string) (*model.Post, *model.AppError) {
 }
 
 // GetPost indicates an expected call of GetPost.
-func (mr *MockAPIMockRecorder) GetPost(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPost", reflect.TypeOf((*MockAPI)(nil).GetPost), arg0)
 }
@@ -1122,7 +1122,7 @@ func (m *MockAPI) GetPostThread(arg0 string) (*model.PostList, *model.AppError) 
 }
 
 // GetPostThread indicates an expected call of GetPostThread.
-func (mr *MockAPIMockRecorder) GetPostThread(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPostThread(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostThread", reflect.TypeOf((*MockAPI)(nil).GetPostThread), arg0)
 }
@@ -1137,7 +1137,7 @@ func (m *MockAPI) GetPostsAfter(arg0, arg1 string, arg2, arg3 int) (*model.PostL
 }
 
 // GetPostsAfter indicates an expected call of GetPostsAfter.
-func (mr *MockAPIMockRecorder) GetPostsAfter(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPostsAfter(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostsAfter", reflect.TypeOf((*MockAPI)(nil).GetPostsAfter), arg0, arg1, arg2, arg3)
 }
@@ -1152,7 +1152,7 @@ func (m *MockAPI) GetPostsBefore(arg0, arg1 string, arg2, arg3 int) (*model.Post
 }
 
 // GetPostsBefore indicates an expected call of GetPostsBefore.
-func (mr *MockAPIMockRecorder) GetPostsBefore(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPostsBefore(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostsBefore", reflect.TypeOf((*MockAPI)(nil).GetPostsBefore), arg0, arg1, arg2, arg3)
 }
@@ -1167,7 +1167,7 @@ func (m *MockAPI) GetPostsForChannel(arg0 string, arg1, arg2 int) (*model.PostLi
 }
 
 // GetPostsForChannel indicates an expected call of GetPostsForChannel.
-func (mr *MockAPIMockRecorder) GetPostsForChannel(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPostsForChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostsForChannel", reflect.TypeOf((*MockAPI)(nil).GetPostsForChannel), arg0, arg1, arg2)
 }
@@ -1182,7 +1182,7 @@ func (m *MockAPI) GetPostsSince(arg0 string, arg1 int64) (*model.PostList, *mode
 }
 
 // GetPostsSince indicates an expected call of GetPostsSince.
-func (mr *MockAPIMockRecorder) GetPostsSince(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPostsSince(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostsSince", reflect.TypeOf((*MockAPI)(nil).GetPostsSince), arg0, arg1)
 }
@@ -1197,7 +1197,7 @@ func (m *MockAPI) GetPreferenceForUser(arg0, arg1, arg2 string) (model.Preferenc
 }
 
 // GetPreferenceForUser indicates an expected call of GetPreferenceForUser.
-func (mr *MockAPIMockRecorder) GetPreferenceForUser(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPreferenceForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreferenceForUser", reflect.TypeOf((*MockAPI)(nil).GetPreferenceForUser), arg0, arg1, arg2)
 }
@@ -1212,7 +1212,7 @@ func (m *MockAPI) GetPreferencesForUser(arg0 string) ([]model.Preference, *model
 }
 
 // GetPreferencesForUser indicates an expected call of GetPreferencesForUser.
-func (mr *MockAPIMockRecorder) GetPreferencesForUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPreferencesForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreferencesForUser", reflect.TypeOf((*MockAPI)(nil).GetPreferencesForUser), arg0)
 }
@@ -1227,7 +1227,7 @@ func (m *MockAPI) GetProfileImage(arg0 string) ([]byte, *model.AppError) {
 }
 
 // GetProfileImage indicates an expected call of GetProfileImage.
-func (mr *MockAPIMockRecorder) GetProfileImage(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetProfileImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfileImage", reflect.TypeOf((*MockAPI)(nil).GetProfileImage), arg0)
 }
@@ -1242,7 +1242,7 @@ func (m *MockAPI) GetPublicChannelsForTeam(arg0 string, arg1, arg2 int) ([]*mode
 }
 
 // GetPublicChannelsForTeam indicates an expected call of GetPublicChannelsForTeam.
-func (mr *MockAPIMockRecorder) GetPublicChannelsForTeam(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPublicChannelsForTeam(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicChannelsForTeam", reflect.TypeOf((*MockAPI)(nil).GetPublicChannelsForTeam), arg0, arg1, arg2)
 }
@@ -1257,7 +1257,7 @@ func (m *MockAPI) GetReactions(arg0 string) ([]*model.Reaction, *model.AppError)
 }
 
 // GetReactions indicates an expected call of GetReactions.
-func (mr *MockAPIMockRecorder) GetReactions(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetReactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReactions", reflect.TypeOf((*MockAPI)(nil).GetReactions), arg0)
 }
@@ -1286,7 +1286,7 @@ func (m *MockAPI) GetSession(arg0 string) (*model.Session, *model.AppError) {
 }
 
 // GetSession indicates an expected call of GetSession.
-func (mr *MockAPIMockRecorder) GetSession(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*MockAPI)(nil).GetSession), arg0)
 }
@@ -1316,7 +1316,7 @@ func (m *MockAPI) GetTeam(arg0 string) (*model.Team, *model.AppError) {
 }
 
 // GetTeam indicates an expected call of GetTeam.
-func (mr *MockAPIMockRecorder) GetTeam(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeam(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeam", reflect.TypeOf((*MockAPI)(nil).GetTeam), arg0)
 }
@@ -1331,7 +1331,7 @@ func (m *MockAPI) GetTeamByName(arg0 string) (*model.Team, *model.AppError) {
 }
 
 // GetTeamByName indicates an expected call of GetTeamByName.
-func (mr *MockAPIMockRecorder) GetTeamByName(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamByName", reflect.TypeOf((*MockAPI)(nil).GetTeamByName), arg0)
 }
@@ -1346,7 +1346,7 @@ func (m *MockAPI) GetTeamIcon(arg0 string) ([]byte, *model.AppError) {
 }
 
 // GetTeamIcon indicates an expected call of GetTeamIcon.
-func (mr *MockAPIMockRecorder) GetTeamIcon(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamIcon(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamIcon", reflect.TypeOf((*MockAPI)(nil).GetTeamIcon), arg0)
 }
@@ -1361,7 +1361,7 @@ func (m *MockAPI) GetTeamMember(arg0, arg1 string) (*model.TeamMember, *model.Ap
 }
 
 // GetTeamMember indicates an expected call of GetTeamMember.
-func (mr *MockAPIMockRecorder) GetTeamMember(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamMember(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMember", reflect.TypeOf((*MockAPI)(nil).GetTeamMember), arg0, arg1)
 }
@@ -1376,7 +1376,7 @@ func (m *MockAPI) GetTeamMembers(arg0 string, arg1, arg2 int) ([]*model.TeamMemb
 }
 
 // GetTeamMembers indicates an expected call of GetTeamMembers.
-func (mr *MockAPIMockRecorder) GetTeamMembers(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamMembers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPI)(nil).GetTeamMembers), arg0, arg1, arg2)
 }
@@ -1391,7 +1391,7 @@ func (m *MockAPI) GetTeamMembersForUser(arg0 string, arg1, arg2 int) ([]*model.T
 }
 
 // GetTeamMembersForUser indicates an expected call of GetTeamMembersForUser.
-func (mr *MockAPIMockRecorder) GetTeamMembersForUser(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamMembersForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembersForUser", reflect.TypeOf((*MockAPI)(nil).GetTeamMembersForUser), arg0, arg1, arg2)
 }
@@ -1406,7 +1406,7 @@ func (m *MockAPI) GetTeamStats(arg0 string) (*model.TeamStats, *model.AppError) 
 }
 
 // GetTeamStats indicates an expected call of GetTeamStats.
-func (mr *MockAPIMockRecorder) GetTeamStats(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamStats(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamStats", reflect.TypeOf((*MockAPI)(nil).GetTeamStats), arg0)
 }
@@ -1436,7 +1436,7 @@ func (m *MockAPI) GetTeamsForUser(arg0 string) ([]*model.Team, *model.AppError) 
 }
 
 // GetTeamsForUser indicates an expected call of GetTeamsForUser.
-func (mr *MockAPIMockRecorder) GetTeamsForUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamsForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamsForUser", reflect.TypeOf((*MockAPI)(nil).GetTeamsForUser), arg0)
 }
@@ -1451,7 +1451,7 @@ func (m *MockAPI) GetTeamsUnreadForUser(arg0 string) ([]*model.TeamUnread, *mode
 }
 
 // GetTeamsUnreadForUser indicates an expected call of GetTeamsUnreadForUser.
-func (mr *MockAPIMockRecorder) GetTeamsUnreadForUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetTeamsUnreadForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamsUnreadForUser", reflect.TypeOf((*MockAPI)(nil).GetTeamsUnreadForUser), arg0)
 }
@@ -1494,7 +1494,7 @@ func (m *MockAPI) GetUploadSession(arg0 string) (*model.UploadSession, error) {
 }
 
 // GetUploadSession indicates an expected call of GetUploadSession.
-func (mr *MockAPIMockRecorder) GetUploadSession(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUploadSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploadSession", reflect.TypeOf((*MockAPI)(nil).GetUploadSession), arg0)
 }
@@ -1509,7 +1509,7 @@ func (m *MockAPI) GetUser(arg0 string) (*model.User, *model.AppError) {
 }
 
 // GetUser indicates an expected call of GetUser.
-func (mr *MockAPIMockRecorder) GetUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockAPI)(nil).GetUser), arg0)
 }
@@ -1524,7 +1524,7 @@ func (m *MockAPI) GetUserByEmail(arg0 string) (*model.User, *model.AppError) {
 }
 
 // GetUserByEmail indicates an expected call of GetUserByEmail.
-func (mr *MockAPIMockRecorder) GetUserByEmail(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUserByEmail(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*MockAPI)(nil).GetUserByEmail), arg0)
 }
@@ -1539,7 +1539,7 @@ func (m *MockAPI) GetUserByUsername(arg0 string) (*model.User, *model.AppError) 
 }
 
 // GetUserByUsername indicates an expected call of GetUserByUsername.
-func (mr *MockAPIMockRecorder) GetUserByUsername(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUserByUsername(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByUsername", reflect.TypeOf((*MockAPI)(nil).GetUserByUsername), arg0)
 }
@@ -1554,7 +1554,7 @@ func (m *MockAPI) GetUserStatus(arg0 string) (*model.Status, *model.AppError) {
 }
 
 // GetUserStatus indicates an expected call of GetUserStatus.
-func (mr *MockAPIMockRecorder) GetUserStatus(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUserStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStatus", reflect.TypeOf((*MockAPI)(nil).GetUserStatus), arg0)
 }
@@ -1569,7 +1569,7 @@ func (m *MockAPI) GetUserStatusesByIds(arg0 []string) ([]*model.Status, *model.A
 }
 
 // GetUserStatusesByIds indicates an expected call of GetUserStatusesByIds.
-func (mr *MockAPIMockRecorder) GetUserStatusesByIds(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUserStatusesByIds(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserStatusesByIds", reflect.TypeOf((*MockAPI)(nil).GetUserStatusesByIds), arg0)
 }
@@ -1584,7 +1584,7 @@ func (m *MockAPI) GetUsers(arg0 *model.UserGetOptions) ([]*model.User, *model.Ap
 }
 
 // GetUsers indicates an expected call of GetUsers.
-func (mr *MockAPIMockRecorder) GetUsers(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUsers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsers", reflect.TypeOf((*MockAPI)(nil).GetUsers), arg0)
 }
@@ -1599,7 +1599,7 @@ func (m *MockAPI) GetUsersByIds(arg0 []string) ([]*model.User, *model.AppError) 
 }
 
 // GetUsersByIds indicates an expected call of GetUsersByIds.
-func (mr *MockAPIMockRecorder) GetUsersByIds(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUsersByIds(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByIds", reflect.TypeOf((*MockAPI)(nil).GetUsersByIds), arg0)
 }
@@ -1614,7 +1614,7 @@ func (m *MockAPI) GetUsersByUsernames(arg0 []string) ([]*model.User, *model.AppE
 }
 
 // GetUsersByUsernames indicates an expected call of GetUsersByUsernames.
-func (mr *MockAPIMockRecorder) GetUsersByUsernames(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUsersByUsernames(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByUsernames", reflect.TypeOf((*MockAPI)(nil).GetUsersByUsernames), arg0)
 }
@@ -1629,7 +1629,7 @@ func (m *MockAPI) GetUsersInChannel(arg0, arg1 string, arg2, arg3 int) ([]*model
 }
 
 // GetUsersInChannel indicates an expected call of GetUsersInChannel.
-func (mr *MockAPIMockRecorder) GetUsersInChannel(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUsersInChannel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersInChannel", reflect.TypeOf((*MockAPI)(nil).GetUsersInChannel), arg0, arg1, arg2, arg3)
 }
@@ -1644,7 +1644,7 @@ func (m *MockAPI) GetUsersInTeam(arg0 string, arg1, arg2 int) ([]*model.User, *m
 }
 
 // GetUsersInTeam indicates an expected call of GetUsersInTeam.
-func (mr *MockAPIMockRecorder) GetUsersInTeam(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetUsersInTeam(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersInTeam", reflect.TypeOf((*MockAPI)(nil).GetUsersInTeam), arg0, arg1, arg2)
 }
@@ -1658,7 +1658,7 @@ func (m *MockAPI) HasPermissionTo(arg0 string, arg1 *model.Permission) bool {
 }
 
 // HasPermissionTo indicates an expected call of HasPermissionTo.
-func (mr *MockAPIMockRecorder) HasPermissionTo(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) HasPermissionTo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermissionTo", reflect.TypeOf((*MockAPI)(nil).HasPermissionTo), arg0, arg1)
 }
@@ -1672,7 +1672,7 @@ func (m *MockAPI) HasPermissionToChannel(arg0, arg1 string, arg2 *model.Permissi
 }
 
 // HasPermissionToChannel indicates an expected call of HasPermissionToChannel.
-func (mr *MockAPIMockRecorder) HasPermissionToChannel(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) HasPermissionToChannel(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermissionToChannel", reflect.TypeOf((*MockAPI)(nil).HasPermissionToChannel), arg0, arg1, arg2)
 }
@@ -1686,7 +1686,7 @@ func (m *MockAPI) HasPermissionToTeam(arg0, arg1 string, arg2 *model.Permission)
 }
 
 // HasPermissionToTeam indicates an expected call of HasPermissionToTeam.
-func (mr *MockAPIMockRecorder) HasPermissionToTeam(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) HasPermissionToTeam(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermissionToTeam", reflect.TypeOf((*MockAPI)(nil).HasPermissionToTeam), arg0, arg1, arg2)
 }
@@ -1701,7 +1701,7 @@ func (m *MockAPI) InstallPlugin(arg0 io.Reader, arg1 bool) (*model.Manifest, *mo
 }
 
 // InstallPlugin indicates an expected call of InstallPlugin.
-func (mr *MockAPIMockRecorder) InstallPlugin(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) InstallPlugin(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPlugin", reflect.TypeOf((*MockAPI)(nil).InstallPlugin), arg0, arg1)
 }
@@ -1715,7 +1715,7 @@ func (m *MockAPI) InviteRemoteToChannel(arg0, arg1, arg2 string, arg3 bool) erro
 }
 
 // InviteRemoteToChannel indicates an expected call of InviteRemoteToChannel.
-func (mr *MockAPIMockRecorder) InviteRemoteToChannel(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) InviteRemoteToChannel(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InviteRemoteToChannel", reflect.TypeOf((*MockAPI)(nil).InviteRemoteToChannel), arg0, arg1, arg2, arg3)
 }
@@ -1744,7 +1744,7 @@ func (m *MockAPI) KVCompareAndDelete(arg0 string, arg1 []byte) (bool, *model.App
 }
 
 // KVCompareAndDelete indicates an expected call of KVCompareAndDelete.
-func (mr *MockAPIMockRecorder) KVCompareAndDelete(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVCompareAndDelete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVCompareAndDelete", reflect.TypeOf((*MockAPI)(nil).KVCompareAndDelete), arg0, arg1)
 }
@@ -1759,7 +1759,7 @@ func (m *MockAPI) KVCompareAndSet(arg0 string, arg1, arg2 []byte) (bool, *model.
 }
 
 // KVCompareAndSet indicates an expected call of KVCompareAndSet.
-func (mr *MockAPIMockRecorder) KVCompareAndSet(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVCompareAndSet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVCompareAndSet", reflect.TypeOf((*MockAPI)(nil).KVCompareAndSet), arg0, arg1, arg2)
 }
@@ -1773,7 +1773,7 @@ func (m *MockAPI) KVDelete(arg0 string) *model.AppError {
 }
 
 // KVDelete indicates an expected call of KVDelete.
-func (mr *MockAPIMockRecorder) KVDelete(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVDelete(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVDelete", reflect.TypeOf((*MockAPI)(nil).KVDelete), arg0)
 }
@@ -1802,7 +1802,7 @@ func (m *MockAPI) KVGet(arg0 string) ([]byte, *model.AppError) {
 }
 
 // KVGet indicates an expected call of KVGet.
-func (mr *MockAPIMockRecorder) KVGet(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVGet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVGet", reflect.TypeOf((*MockAPI)(nil).KVGet), arg0)
 }
@@ -1817,7 +1817,7 @@ func (m *MockAPI) KVList(arg0, arg1 int) ([]string, *model.AppError) {
 }
 
 // KVList indicates an expected call of KVList.
-func (mr *MockAPIMockRecorder) KVList(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVList(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVList", reflect.TypeOf((*MockAPI)(nil).KVList), arg0, arg1)
 }
@@ -1831,7 +1831,7 @@ func (m *MockAPI) KVSet(arg0 string, arg1 []byte) *model.AppError {
 }
 
 // KVSet indicates an expected call of KVSet.
-func (mr *MockAPIMockRecorder) KVSet(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVSet(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVSet", reflect.TypeOf((*MockAPI)(nil).KVSet), arg0, arg1)
 }
@@ -1845,7 +1845,7 @@ func (m *MockAPI) KVSetWithExpiry(arg0 string, arg1 []byte, arg2 int64) *model.A
 }
 
 // KVSetWithExpiry indicates an expected call of KVSetWithExpiry.
-func (mr *MockAPIMockRecorder) KVSetWithExpiry(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVSetWithExpiry(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVSetWithExpiry", reflect.TypeOf((*MockAPI)(nil).KVSetWithExpiry), arg0, arg1, arg2)
 }
@@ -1860,7 +1860,7 @@ func (m *MockAPI) KVSetWithOptions(arg0 string, arg1 []byte, arg2 model.PluginKV
 }
 
 // KVSetWithOptions indicates an expected call of KVSetWithOptions.
-func (mr *MockAPIMockRecorder) KVSetWithOptions(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) KVSetWithOptions(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVSetWithOptions", reflect.TypeOf((*MockAPI)(nil).KVSetWithOptions), arg0, arg1, arg2)
 }
@@ -1890,7 +1890,7 @@ func (m *MockAPI) ListCommands(arg0 string) ([]*model.Command, error) {
 }
 
 // ListCommands indicates an expected call of ListCommands.
-func (mr *MockAPIMockRecorder) ListCommands(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ListCommands(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommands", reflect.TypeOf((*MockAPI)(nil).ListCommands), arg0)
 }
@@ -1905,7 +1905,7 @@ func (m *MockAPI) ListCustomCommands(arg0 string) ([]*model.Command, error) {
 }
 
 // ListCustomCommands indicates an expected call of ListCustomCommands.
-func (mr *MockAPIMockRecorder) ListCustomCommands(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ListCustomCommands(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCustomCommands", reflect.TypeOf((*MockAPI)(nil).ListCustomCommands), arg0)
 }
@@ -1920,13 +1920,13 @@ func (m *MockAPI) ListPluginCommands(arg0 string) ([]*model.Command, error) {
 }
 
 // ListPluginCommands indicates an expected call of ListPluginCommands.
-func (mr *MockAPIMockRecorder) ListPluginCommands(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ListPluginCommands(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPluginCommands", reflect.TypeOf((*MockAPI)(nil).ListPluginCommands), arg0)
 }
 
 // LoadPluginConfiguration mocks base method.
-func (m *MockAPI) LoadPluginConfiguration(arg0 any) error {
+func (m *MockAPI) LoadPluginConfiguration(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadPluginConfiguration", arg0)
 	ret0, _ := ret[0].(error)
@@ -1934,15 +1934,15 @@ func (m *MockAPI) LoadPluginConfiguration(arg0 any) error {
 }
 
 // LoadPluginConfiguration indicates an expected call of LoadPluginConfiguration.
-func (mr *MockAPIMockRecorder) LoadPluginConfiguration(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) LoadPluginConfiguration(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadPluginConfiguration", reflect.TypeOf((*MockAPI)(nil).LoadPluginConfiguration), arg0)
 }
 
 // LogDebug mocks base method.
-func (m *MockAPI) LogDebug(arg0 string, arg1 ...any) {
+func (m *MockAPI) LogDebug(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
+	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
@@ -1950,16 +1950,16 @@ func (m *MockAPI) LogDebug(arg0 string, arg1 ...any) {
 }
 
 // LogDebug indicates an expected call of LogDebug.
-func (mr *MockAPIMockRecorder) LogDebug(arg0 any, arg1 ...any) *gomock.Call {
+func (mr *MockAPIMockRecorder) LogDebug(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
+	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogDebug", reflect.TypeOf((*MockAPI)(nil).LogDebug), varargs...)
 }
 
 // LogError mocks base method.
-func (m *MockAPI) LogError(arg0 string, arg1 ...any) {
+func (m *MockAPI) LogError(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
+	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
@@ -1967,16 +1967,16 @@ func (m *MockAPI) LogError(arg0 string, arg1 ...any) {
 }
 
 // LogError indicates an expected call of LogError.
-func (mr *MockAPIMockRecorder) LogError(arg0 any, arg1 ...any) *gomock.Call {
+func (mr *MockAPIMockRecorder) LogError(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
+	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogError", reflect.TypeOf((*MockAPI)(nil).LogError), varargs...)
 }
 
 // LogInfo mocks base method.
-func (m *MockAPI) LogInfo(arg0 string, arg1 ...any) {
+func (m *MockAPI) LogInfo(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
+	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
@@ -1984,16 +1984,16 @@ func (m *MockAPI) LogInfo(arg0 string, arg1 ...any) {
 }
 
 // LogInfo indicates an expected call of LogInfo.
-func (mr *MockAPIMockRecorder) LogInfo(arg0 any, arg1 ...any) *gomock.Call {
+func (mr *MockAPIMockRecorder) LogInfo(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
+	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogInfo", reflect.TypeOf((*MockAPI)(nil).LogInfo), varargs...)
 }
 
 // LogWarn mocks base method.
-func (m *MockAPI) LogWarn(arg0 string, arg1 ...any) {
+func (m *MockAPI) LogWarn(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
+	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
@@ -2001,9 +2001,9 @@ func (m *MockAPI) LogWarn(arg0 string, arg1 ...any) {
 }
 
 // LogWarn indicates an expected call of LogWarn.
-func (mr *MockAPIMockRecorder) LogWarn(arg0 any, arg1 ...any) *gomock.Call {
+func (mr *MockAPIMockRecorder) LogWarn(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
+	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogWarn", reflect.TypeOf((*MockAPI)(nil).LogWarn), varargs...)
 }
 
@@ -2016,7 +2016,7 @@ func (m *MockAPI) OpenInteractiveDialog(arg0 model.OpenDialogRequest) *model.App
 }
 
 // OpenInteractiveDialog indicates an expected call of OpenInteractiveDialog.
-func (mr *MockAPIMockRecorder) OpenInteractiveDialog(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) OpenInteractiveDialog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenInteractiveDialog", reflect.TypeOf((*MockAPI)(nil).OpenInteractiveDialog), arg0)
 }
@@ -2031,7 +2031,7 @@ func (m *MockAPI) PatchBot(arg0 string, arg1 *model.BotPatch) (*model.Bot, *mode
 }
 
 // PatchBot indicates an expected call of PatchBot.
-func (mr *MockAPIMockRecorder) PatchBot(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PatchBot(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBot", reflect.TypeOf((*MockAPI)(nil).PatchBot), arg0, arg1)
 }
@@ -2045,7 +2045,7 @@ func (m *MockAPI) PatchChannelMembersNotifications(arg0 []*model.ChannelMemberId
 }
 
 // PatchChannelMembersNotifications indicates an expected call of PatchChannelMembersNotifications.
-func (mr *MockAPIMockRecorder) PatchChannelMembersNotifications(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PatchChannelMembersNotifications(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchChannelMembersNotifications", reflect.TypeOf((*MockAPI)(nil).PatchChannelMembersNotifications), arg0, arg1)
 }
@@ -2059,7 +2059,7 @@ func (m *MockAPI) PermanentDeleteBot(arg0 string) *model.AppError {
 }
 
 // PermanentDeleteBot indicates an expected call of PermanentDeleteBot.
-func (mr *MockAPIMockRecorder) PermanentDeleteBot(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PermanentDeleteBot(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PermanentDeleteBot", reflect.TypeOf((*MockAPI)(nil).PermanentDeleteBot), arg0)
 }
@@ -2073,7 +2073,7 @@ func (m *MockAPI) PluginHTTP(arg0 *http.Request) *http.Response {
 }
 
 // PluginHTTP indicates an expected call of PluginHTTP.
-func (mr *MockAPIMockRecorder) PluginHTTP(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PluginHTTP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PluginHTTP", reflect.TypeOf((*MockAPI)(nil).PluginHTTP), arg0)
 }
@@ -2087,7 +2087,7 @@ func (m *MockAPI) PublishPluginClusterEvent(arg0 model.PluginClusterEvent, arg1 
 }
 
 // PublishPluginClusterEvent indicates an expected call of PublishPluginClusterEvent.
-func (mr *MockAPIMockRecorder) PublishPluginClusterEvent(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PublishPluginClusterEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishPluginClusterEvent", reflect.TypeOf((*MockAPI)(nil).PublishPluginClusterEvent), arg0, arg1)
 }
@@ -2101,19 +2101,19 @@ func (m *MockAPI) PublishUserTyping(arg0, arg1, arg2 string) *model.AppError {
 }
 
 // PublishUserTyping indicates an expected call of PublishUserTyping.
-func (mr *MockAPIMockRecorder) PublishUserTyping(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PublishUserTyping(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishUserTyping", reflect.TypeOf((*MockAPI)(nil).PublishUserTyping), arg0, arg1, arg2)
 }
 
 // PublishWebSocketEvent mocks base method.
-func (m *MockAPI) PublishWebSocketEvent(arg0 string, arg1 map[string]any, arg2 *model.WebsocketBroadcast) {
+func (m *MockAPI) PublishWebSocketEvent(arg0 string, arg1 map[string]interface{}, arg2 *model.WebsocketBroadcast) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PublishWebSocketEvent", arg0, arg1, arg2)
 }
 
 // PublishWebSocketEvent indicates an expected call of PublishWebSocketEvent.
-func (mr *MockAPIMockRecorder) PublishWebSocketEvent(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) PublishWebSocketEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWebSocketEvent", reflect.TypeOf((*MockAPI)(nil).PublishWebSocketEvent), arg0, arg1, arg2)
 }
@@ -2128,7 +2128,7 @@ func (m *MockAPI) ReadFile(arg0 string) ([]byte, *model.AppError) {
 }
 
 // ReadFile indicates an expected call of ReadFile.
-func (mr *MockAPIMockRecorder) ReadFile(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockAPI)(nil).ReadFile), arg0)
 }
@@ -2142,7 +2142,7 @@ func (m *MockAPI) RegisterCollectionAndTopic(arg0, arg1 string) error {
 }
 
 // RegisterCollectionAndTopic indicates an expected call of RegisterCollectionAndTopic.
-func (mr *MockAPIMockRecorder) RegisterCollectionAndTopic(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RegisterCollectionAndTopic(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCollectionAndTopic", reflect.TypeOf((*MockAPI)(nil).RegisterCollectionAndTopic), arg0, arg1)
 }
@@ -2156,7 +2156,7 @@ func (m *MockAPI) RegisterCommand(arg0 *model.Command) error {
 }
 
 // RegisterCommand indicates an expected call of RegisterCommand.
-func (mr *MockAPIMockRecorder) RegisterCommand(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RegisterCommand(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCommand", reflect.TypeOf((*MockAPI)(nil).RegisterCommand), arg0)
 }
@@ -2171,7 +2171,7 @@ func (m *MockAPI) RegisterPluginForSharedChannels(arg0 model.RegisterPluginOpts)
 }
 
 // RegisterPluginForSharedChannels indicates an expected call of RegisterPluginForSharedChannels.
-func (mr *MockAPIMockRecorder) RegisterPluginForSharedChannels(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RegisterPluginForSharedChannels(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPluginForSharedChannels", reflect.TypeOf((*MockAPI)(nil).RegisterPluginForSharedChannels), arg0)
 }
@@ -2185,7 +2185,7 @@ func (m *MockAPI) RemovePlugin(arg0 string) *model.AppError {
 }
 
 // RemovePlugin indicates an expected call of RemovePlugin.
-func (mr *MockAPIMockRecorder) RemovePlugin(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RemovePlugin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePlugin", reflect.TypeOf((*MockAPI)(nil).RemovePlugin), arg0)
 }
@@ -2199,7 +2199,7 @@ func (m *MockAPI) RemoveReaction(arg0 *model.Reaction) *model.AppError {
 }
 
 // RemoveReaction indicates an expected call of RemoveReaction.
-func (mr *MockAPIMockRecorder) RemoveReaction(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RemoveReaction(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveReaction", reflect.TypeOf((*MockAPI)(nil).RemoveReaction), arg0)
 }
@@ -2213,7 +2213,7 @@ func (m *MockAPI) RemoveTeamIcon(arg0 string) *model.AppError {
 }
 
 // RemoveTeamIcon indicates an expected call of RemoveTeamIcon.
-func (mr *MockAPIMockRecorder) RemoveTeamIcon(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RemoveTeamIcon(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTeamIcon", reflect.TypeOf((*MockAPI)(nil).RemoveTeamIcon), arg0)
 }
@@ -2227,7 +2227,7 @@ func (m *MockAPI) RemoveUserCustomStatus(arg0 string) *model.AppError {
 }
 
 // RemoveUserCustomStatus indicates an expected call of RemoveUserCustomStatus.
-func (mr *MockAPIMockRecorder) RemoveUserCustomStatus(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RemoveUserCustomStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserCustomStatus", reflect.TypeOf((*MockAPI)(nil).RemoveUserCustomStatus), arg0)
 }
@@ -2241,7 +2241,7 @@ func (m *MockAPI) RequestTrialLicense(arg0 string, arg1 int, arg2, arg3 bool) *m
 }
 
 // RequestTrialLicense indicates an expected call of RequestTrialLicense.
-func (mr *MockAPIMockRecorder) RequestTrialLicense(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RequestTrialLicense(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestTrialLicense", reflect.TypeOf((*MockAPI)(nil).RequestTrialLicense), arg0, arg1, arg2, arg3)
 }
@@ -2255,7 +2255,7 @@ func (m *MockAPI) RevokeSession(arg0 string) *model.AppError {
 }
 
 // RevokeSession indicates an expected call of RevokeSession.
-func (mr *MockAPIMockRecorder) RevokeSession(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RevokeSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSession", reflect.TypeOf((*MockAPI)(nil).RevokeSession), arg0)
 }
@@ -2269,7 +2269,7 @@ func (m *MockAPI) RevokeUserAccessToken(arg0 string) *model.AppError {
 }
 
 // RevokeUserAccessToken indicates an expected call of RevokeUserAccessToken.
-func (mr *MockAPIMockRecorder) RevokeUserAccessToken(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RevokeUserAccessToken(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeUserAccessToken", reflect.TypeOf((*MockAPI)(nil).RevokeUserAccessToken), arg0)
 }
@@ -2283,7 +2283,7 @@ func (m *MockAPI) RolesGrantPermission(arg0 []string, arg1 string) bool {
 }
 
 // RolesGrantPermission indicates an expected call of RolesGrantPermission.
-func (mr *MockAPIMockRecorder) RolesGrantPermission(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) RolesGrantPermission(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RolesGrantPermission", reflect.TypeOf((*MockAPI)(nil).RolesGrantPermission), arg0, arg1)
 }
@@ -2297,13 +2297,13 @@ func (m *MockAPI) SaveConfig(arg0 *model.Config) *model.AppError {
 }
 
 // SaveConfig indicates an expected call of SaveConfig.
-func (mr *MockAPIMockRecorder) SaveConfig(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SaveConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveConfig", reflect.TypeOf((*MockAPI)(nil).SaveConfig), arg0)
 }
 
 // SavePluginConfig mocks base method.
-func (m *MockAPI) SavePluginConfig(arg0 map[string]any) *model.AppError {
+func (m *MockAPI) SavePluginConfig(arg0 map[string]interface{}) *model.AppError {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SavePluginConfig", arg0)
 	ret0, _ := ret[0].(*model.AppError)
@@ -2311,7 +2311,7 @@ func (m *MockAPI) SavePluginConfig(arg0 map[string]any) *model.AppError {
 }
 
 // SavePluginConfig indicates an expected call of SavePluginConfig.
-func (mr *MockAPIMockRecorder) SavePluginConfig(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SavePluginConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavePluginConfig", reflect.TypeOf((*MockAPI)(nil).SavePluginConfig), arg0)
 }
@@ -2326,7 +2326,7 @@ func (m *MockAPI) SearchChannels(arg0, arg1 string) ([]*model.Channel, *model.Ap
 }
 
 // SearchChannels indicates an expected call of SearchChannels.
-func (mr *MockAPIMockRecorder) SearchChannels(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SearchChannels(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchChannels", reflect.TypeOf((*MockAPI)(nil).SearchChannels), arg0, arg1)
 }
@@ -2341,7 +2341,7 @@ func (m *MockAPI) SearchPostsInTeam(arg0 string, arg1 []*model.SearchParams) ([]
 }
 
 // SearchPostsInTeam indicates an expected call of SearchPostsInTeam.
-func (mr *MockAPIMockRecorder) SearchPostsInTeam(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SearchPostsInTeam(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchPostsInTeam", reflect.TypeOf((*MockAPI)(nil).SearchPostsInTeam), arg0, arg1)
 }
@@ -2356,7 +2356,7 @@ func (m *MockAPI) SearchPostsInTeamForUser(arg0, arg1 string, arg2 model.SearchP
 }
 
 // SearchPostsInTeamForUser indicates an expected call of SearchPostsInTeamForUser.
-func (mr *MockAPIMockRecorder) SearchPostsInTeamForUser(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SearchPostsInTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchPostsInTeamForUser", reflect.TypeOf((*MockAPI)(nil).SearchPostsInTeamForUser), arg0, arg1, arg2)
 }
@@ -2371,7 +2371,7 @@ func (m *MockAPI) SearchTeams(arg0 string) ([]*model.Team, *model.AppError) {
 }
 
 // SearchTeams indicates an expected call of SearchTeams.
-func (mr *MockAPIMockRecorder) SearchTeams(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SearchTeams(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTeams", reflect.TypeOf((*MockAPI)(nil).SearchTeams), arg0)
 }
@@ -2386,7 +2386,7 @@ func (m *MockAPI) SearchUsers(arg0 *model.UserSearch) ([]*model.User, *model.App
 }
 
 // SearchUsers indicates an expected call of SearchUsers.
-func (mr *MockAPIMockRecorder) SearchUsers(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SearchUsers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchUsers", reflect.TypeOf((*MockAPI)(nil).SearchUsers), arg0)
 }
@@ -2400,7 +2400,7 @@ func (m *MockAPI) SendEphemeralPost(arg0 string, arg1 *model.Post) *model.Post {
 }
 
 // SendEphemeralPost indicates an expected call of SendEphemeralPost.
-func (mr *MockAPIMockRecorder) SendEphemeralPost(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SendEphemeralPost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendEphemeralPost", reflect.TypeOf((*MockAPI)(nil).SendEphemeralPost), arg0, arg1)
 }
@@ -2414,7 +2414,7 @@ func (m *MockAPI) SendMail(arg0, arg1, arg2 string) *model.AppError {
 }
 
 // SendMail indicates an expected call of SendMail.
-func (mr *MockAPIMockRecorder) SendMail(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SendMail(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMail", reflect.TypeOf((*MockAPI)(nil).SendMail), arg0, arg1, arg2)
 }
@@ -2428,7 +2428,7 @@ func (m *MockAPI) SendPushNotification(arg0 *model.PushNotification, arg1 string
 }
 
 // SendPushNotification indicates an expected call of SendPushNotification.
-func (mr *MockAPIMockRecorder) SendPushNotification(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SendPushNotification(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPushNotification", reflect.TypeOf((*MockAPI)(nil).SendPushNotification), arg0, arg1)
 }
@@ -2442,7 +2442,7 @@ func (m *MockAPI) SetFileSearchableContent(arg0, arg1 string) *model.AppError {
 }
 
 // SetFileSearchableContent indicates an expected call of SetFileSearchableContent.
-func (mr *MockAPIMockRecorder) SetFileSearchableContent(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetFileSearchableContent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFileSearchableContent", reflect.TypeOf((*MockAPI)(nil).SetFileSearchableContent), arg0, arg1)
 }
@@ -2456,7 +2456,7 @@ func (m *MockAPI) SetProfileImage(arg0 string, arg1 []byte) *model.AppError {
 }
 
 // SetProfileImage indicates an expected call of SetProfileImage.
-func (mr *MockAPIMockRecorder) SetProfileImage(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetProfileImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProfileImage", reflect.TypeOf((*MockAPI)(nil).SetProfileImage), arg0, arg1)
 }
@@ -2470,7 +2470,7 @@ func (m *MockAPI) SetTeamIcon(arg0 string, arg1 []byte) *model.AppError {
 }
 
 // SetTeamIcon indicates an expected call of SetTeamIcon.
-func (mr *MockAPIMockRecorder) SetTeamIcon(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetTeamIcon(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTeamIcon", reflect.TypeOf((*MockAPI)(nil).SetTeamIcon), arg0, arg1)
 }
@@ -2485,7 +2485,7 @@ func (m *MockAPI) SetUserStatusTimedDND(arg0 string, arg1 int64) (*model.Status,
 }
 
 // SetUserStatusTimedDND indicates an expected call of SetUserStatusTimedDND.
-func (mr *MockAPIMockRecorder) SetUserStatusTimedDND(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SetUserStatusTimedDND(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUserStatusTimedDND", reflect.TypeOf((*MockAPI)(nil).SetUserStatusTimedDND), arg0, arg1)
 }
@@ -2500,7 +2500,7 @@ func (m *MockAPI) ShareChannel(arg0 *model.SharedChannel) (*model.SharedChannel,
 }
 
 // ShareChannel indicates an expected call of ShareChannel.
-func (mr *MockAPIMockRecorder) ShareChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ShareChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShareChannel", reflect.TypeOf((*MockAPI)(nil).ShareChannel), arg0)
 }
@@ -2514,7 +2514,7 @@ func (m *MockAPI) SyncSharedChannel(arg0 string) error {
 }
 
 // SyncSharedChannel indicates an expected call of SyncSharedChannel.
-func (mr *MockAPIMockRecorder) SyncSharedChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) SyncSharedChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSharedChannel", reflect.TypeOf((*MockAPI)(nil).SyncSharedChannel), arg0)
 }
@@ -2528,7 +2528,7 @@ func (m *MockAPI) UninviteRemoteFromChannel(arg0, arg1 string) error {
 }
 
 // UninviteRemoteFromChannel indicates an expected call of UninviteRemoteFromChannel.
-func (mr *MockAPIMockRecorder) UninviteRemoteFromChannel(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UninviteRemoteFromChannel(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninviteRemoteFromChannel", reflect.TypeOf((*MockAPI)(nil).UninviteRemoteFromChannel), arg0, arg1)
 }
@@ -2542,7 +2542,7 @@ func (m *MockAPI) UnregisterCommand(arg0, arg1 string) error {
 }
 
 // UnregisterCommand indicates an expected call of UnregisterCommand.
-func (mr *MockAPIMockRecorder) UnregisterCommand(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UnregisterCommand(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterCommand", reflect.TypeOf((*MockAPI)(nil).UnregisterCommand), arg0, arg1)
 }
@@ -2556,7 +2556,7 @@ func (m *MockAPI) UnregisterPluginForSharedChannels(arg0 string) error {
 }
 
 // UnregisterPluginForSharedChannels indicates an expected call of UnregisterPluginForSharedChannels.
-func (mr *MockAPIMockRecorder) UnregisterPluginForSharedChannels(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UnregisterPluginForSharedChannels(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterPluginForSharedChannels", reflect.TypeOf((*MockAPI)(nil).UnregisterPluginForSharedChannels), arg0)
 }
@@ -2571,7 +2571,7 @@ func (m *MockAPI) UnshareChannel(arg0 string) (bool, error) {
 }
 
 // UnshareChannel indicates an expected call of UnshareChannel.
-func (mr *MockAPIMockRecorder) UnshareChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UnshareChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnshareChannel", reflect.TypeOf((*MockAPI)(nil).UnshareChannel), arg0)
 }
@@ -2586,7 +2586,7 @@ func (m *MockAPI) UpdateBotActive(arg0 string, arg1 bool) (*model.Bot, *model.Ap
 }
 
 // UpdateBotActive indicates an expected call of UpdateBotActive.
-func (mr *MockAPIMockRecorder) UpdateBotActive(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateBotActive(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBotActive", reflect.TypeOf((*MockAPI)(nil).UpdateBotActive), arg0, arg1)
 }
@@ -2601,7 +2601,7 @@ func (m *MockAPI) UpdateChannel(arg0 *model.Channel) (*model.Channel, *model.App
 }
 
 // UpdateChannel indicates an expected call of UpdateChannel.
-func (mr *MockAPIMockRecorder) UpdateChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannel", reflect.TypeOf((*MockAPI)(nil).UpdateChannel), arg0)
 }
@@ -2616,7 +2616,7 @@ func (m *MockAPI) UpdateChannelMemberNotifications(arg0, arg1 string, arg2 map[s
 }
 
 // UpdateChannelMemberNotifications indicates an expected call of UpdateChannelMemberNotifications.
-func (mr *MockAPIMockRecorder) UpdateChannelMemberNotifications(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateChannelMemberNotifications(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannelMemberNotifications", reflect.TypeOf((*MockAPI)(nil).UpdateChannelMemberNotifications), arg0, arg1, arg2)
 }
@@ -2631,7 +2631,7 @@ func (m *MockAPI) UpdateChannelMemberRoles(arg0, arg1, arg2 string) (*model.Chan
 }
 
 // UpdateChannelMemberRoles indicates an expected call of UpdateChannelMemberRoles.
-func (mr *MockAPIMockRecorder) UpdateChannelMemberRoles(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateChannelMemberRoles(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannelMemberRoles", reflect.TypeOf((*MockAPI)(nil).UpdateChannelMemberRoles), arg0, arg1, arg2)
 }
@@ -2646,7 +2646,7 @@ func (m *MockAPI) UpdateChannelSidebarCategories(arg0, arg1 string, arg2 []*mode
 }
 
 // UpdateChannelSidebarCategories indicates an expected call of UpdateChannelSidebarCategories.
-func (mr *MockAPIMockRecorder) UpdateChannelSidebarCategories(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateChannelSidebarCategories(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateChannelSidebarCategories", reflect.TypeOf((*MockAPI)(nil).UpdateChannelSidebarCategories), arg0, arg1, arg2)
 }
@@ -2661,7 +2661,7 @@ func (m *MockAPI) UpdateCommand(arg0 string, arg1 *model.Command) (*model.Comman
 }
 
 // UpdateCommand indicates an expected call of UpdateCommand.
-func (mr *MockAPIMockRecorder) UpdateCommand(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateCommand(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCommand", reflect.TypeOf((*MockAPI)(nil).UpdateCommand), arg0, arg1)
 }
@@ -2675,7 +2675,7 @@ func (m *MockAPI) UpdateEphemeralPost(arg0 string, arg1 *model.Post) *model.Post
 }
 
 // UpdateEphemeralPost indicates an expected call of UpdateEphemeralPost.
-func (mr *MockAPIMockRecorder) UpdateEphemeralPost(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateEphemeralPost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEphemeralPost", reflect.TypeOf((*MockAPI)(nil).UpdateEphemeralPost), arg0, arg1)
 }
@@ -2690,7 +2690,7 @@ func (m *MockAPI) UpdateOAuthApp(arg0 *model.OAuthApp) (*model.OAuthApp, *model.
 }
 
 // UpdateOAuthApp indicates an expected call of UpdateOAuthApp.
-func (mr *MockAPIMockRecorder) UpdateOAuthApp(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateOAuthApp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOAuthApp", reflect.TypeOf((*MockAPI)(nil).UpdateOAuthApp), arg0)
 }
@@ -2705,7 +2705,7 @@ func (m *MockAPI) UpdatePost(arg0 *model.Post) (*model.Post, *model.AppError) {
 }
 
 // UpdatePost indicates an expected call of UpdatePost.
-func (mr *MockAPIMockRecorder) UpdatePost(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdatePost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePost", reflect.TypeOf((*MockAPI)(nil).UpdatePost), arg0)
 }
@@ -2719,7 +2719,7 @@ func (m *MockAPI) UpdatePreferencesForUser(arg0 string, arg1 []model.Preference)
 }
 
 // UpdatePreferencesForUser indicates an expected call of UpdatePreferencesForUser.
-func (mr *MockAPIMockRecorder) UpdatePreferencesForUser(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdatePreferencesForUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePreferencesForUser", reflect.TypeOf((*MockAPI)(nil).UpdatePreferencesForUser), arg0, arg1)
 }
@@ -2734,7 +2734,7 @@ func (m *MockAPI) UpdateSharedChannel(arg0 *model.SharedChannel) (*model.SharedC
 }
 
 // UpdateSharedChannel indicates an expected call of UpdateSharedChannel.
-func (mr *MockAPIMockRecorder) UpdateSharedChannel(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateSharedChannel(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSharedChannel", reflect.TypeOf((*MockAPI)(nil).UpdateSharedChannel), arg0)
 }
@@ -2748,7 +2748,7 @@ func (m *MockAPI) UpdateSharedChannelCursor(arg0, arg1 string, arg2 model.GetPos
 }
 
 // UpdateSharedChannelCursor indicates an expected call of UpdateSharedChannelCursor.
-func (mr *MockAPIMockRecorder) UpdateSharedChannelCursor(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateSharedChannelCursor(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSharedChannelCursor", reflect.TypeOf((*MockAPI)(nil).UpdateSharedChannelCursor), arg0, arg1, arg2)
 }
@@ -2763,7 +2763,7 @@ func (m *MockAPI) UpdateTeam(arg0 *model.Team) (*model.Team, *model.AppError) {
 }
 
 // UpdateTeam indicates an expected call of UpdateTeam.
-func (mr *MockAPIMockRecorder) UpdateTeam(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateTeam(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTeam", reflect.TypeOf((*MockAPI)(nil).UpdateTeam), arg0)
 }
@@ -2778,7 +2778,7 @@ func (m *MockAPI) UpdateTeamMemberRoles(arg0, arg1, arg2 string) (*model.TeamMem
 }
 
 // UpdateTeamMemberRoles indicates an expected call of UpdateTeamMemberRoles.
-func (mr *MockAPIMockRecorder) UpdateTeamMemberRoles(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateTeamMemberRoles(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTeamMemberRoles", reflect.TypeOf((*MockAPI)(nil).UpdateTeamMemberRoles), arg0, arg1, arg2)
 }
@@ -2793,7 +2793,7 @@ func (m *MockAPI) UpdateUser(arg0 *model.User) (*model.User, *model.AppError) {
 }
 
 // UpdateUser indicates an expected call of UpdateUser.
-func (mr *MockAPIMockRecorder) UpdateUser(arg0 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockAPI)(nil).UpdateUser), arg0)
 }
@@ -2807,7 +2807,7 @@ func (m *MockAPI) UpdateUserActive(arg0 string, arg1 bool) *model.AppError {
 }
 
 // UpdateUserActive indicates an expected call of UpdateUserActive.
-func (mr *MockAPIMockRecorder) UpdateUserActive(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUserActive(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserActive", reflect.TypeOf((*MockAPI)(nil).UpdateUserActive), arg0, arg1)
 }
@@ -2822,7 +2822,7 @@ func (m *MockAPI) UpdateUserAuth(arg0 string, arg1 *model.UserAuth) (*model.User
 }
 
 // UpdateUserAuth indicates an expected call of UpdateUserAuth.
-func (mr *MockAPIMockRecorder) UpdateUserAuth(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUserAuth(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserAuth", reflect.TypeOf((*MockAPI)(nil).UpdateUserAuth), arg0, arg1)
 }
@@ -2836,7 +2836,7 @@ func (m *MockAPI) UpdateUserCustomStatus(arg0 string, arg1 *model.CustomStatus) 
 }
 
 // UpdateUserCustomStatus indicates an expected call of UpdateUserCustomStatus.
-func (mr *MockAPIMockRecorder) UpdateUserCustomStatus(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUserCustomStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserCustomStatus", reflect.TypeOf((*MockAPI)(nil).UpdateUserCustomStatus), arg0, arg1)
 }
@@ -2851,7 +2851,7 @@ func (m *MockAPI) UpdateUserRoles(arg0, arg1 string) (*model.User, *model.AppErr
 }
 
 // UpdateUserRoles indicates an expected call of UpdateUserRoles.
-func (mr *MockAPIMockRecorder) UpdateUserRoles(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUserRoles(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserRoles", reflect.TypeOf((*MockAPI)(nil).UpdateUserRoles), arg0, arg1)
 }
@@ -2866,7 +2866,7 @@ func (m *MockAPI) UpdateUserStatus(arg0, arg1 string) (*model.Status, *model.App
 }
 
 // UpdateUserStatus indicates an expected call of UpdateUserStatus.
-func (mr *MockAPIMockRecorder) UpdateUserStatus(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UpdateUserStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserStatus", reflect.TypeOf((*MockAPI)(nil).UpdateUserStatus), arg0, arg1)
 }
@@ -2881,7 +2881,7 @@ func (m *MockAPI) UploadData(arg0 *model.UploadSession, arg1 io.Reader) (*model.
 }
 
 // UploadData indicates an expected call of UploadData.
-func (mr *MockAPIMockRecorder) UploadData(arg0, arg1 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UploadData(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadData", reflect.TypeOf((*MockAPI)(nil).UploadData), arg0, arg1)
 }
@@ -2896,7 +2896,7 @@ func (m *MockAPI) UploadFile(arg0 []byte, arg1, arg2 string) (*model.FileInfo, *
 }
 
 // UploadFile indicates an expected call of UploadFile.
-func (mr *MockAPIMockRecorder) UploadFile(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) UploadFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadFile", reflect.TypeOf((*MockAPI)(nil).UploadFile), arg0, arg1, arg2)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -245,4 +245,21 @@ func (p *Plugin) RunKVStoreMigrations() error {
 	return p.runKVStoreMigrations()
 }
 
+// RunKVStoreMigrationsWithResults exposes migration functionality to command handlers and returns detailed results
+func (p *Plugin) RunKVStoreMigrationsWithResults() (*command.MigrationResult, error) {
+	result, err := p.runKVStoreMigrationsWithResults()
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert from internal MigrationResult to command.MigrationResult
+	return &command.MigrationResult{
+		UserMappingsCreated:      result.UserMappingsCreated,
+		ChannelMappingsCreated:   result.ChannelMappingsCreated,
+		RoomMappingsCreated:      result.RoomMappingsCreated,
+		DMMappingsCreated:        result.DMMappingsCreated,
+		ReverseDMMappingsCreated: result.ReverseDMMappingsCreated,
+	}, nil
+}
+
 // See https://developers.mattermost.com/extend/plugins/server/reference/

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -103,14 +103,15 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrap(err, "failed to run KV store migrations")
 	}
 
-	// Initialize bridge components
-	p.initBridges()
-
-	p.commandClient = command.NewCommandHandler(p)
-
+	// Register for shared channels first to get remote ID
 	if err := p.registerForSharedChannels(); err != nil {
 		p.logger.LogWarn("Failed to register for shared channels", "error", err)
 	}
+
+	// Initialize bridge components after getting remote ID
+	p.initBridges()
+
+	p.commandClient = command.NewCommandHandler(p)
 
 	job, err := cluster.Schedule(
 		p.API,
@@ -237,6 +238,11 @@ func (p *Plugin) GetPluginAPI() plugin.API {
 // GetPluginAPIClient returns the pluginapi client
 func (p *Plugin) GetPluginAPIClient() *pluginapi.Client {
 	return p.client
+}
+
+// RunKVStoreMigrations exposes migration functionality to command handlers
+func (p *Plugin) RunKVStoreMigrations() error {
+	return p.runKVStoreMigrations()
 }
 
 // See https://developers.mattermost.com/extend/plugins/server/reference/

--- a/server/store/kvstore/kvstore.go
+++ b/server/store/kvstore/kvstore.go
@@ -9,4 +9,5 @@ type KVStore interface {
 	Set(key string, value []byte) error
 	Delete(key string) error
 	ListKeys(page, perPage int) ([]string, error)
+	ListKeysWithPrefix(page, perPage int, prefix string) ([]string, error)
 }

--- a/server/store/kvstore/startertemplate.go
+++ b/server/store/kvstore/startertemplate.go
@@ -66,3 +66,12 @@ func (kv Client) ListKeys(page, perPage int) ([]string, error) {
 	}
 	return keys, nil
 }
+
+// ListKeysWithPrefix retrieves a paginated list of keys with a specific prefix from the KV store.
+func (kv Client) ListKeysWithPrefix(page, perPage int, prefix string) ([]string, error) {
+	keys, appErr := kv.client.KV.ListKeys(page, perPage, pluginapi.WithPrefix(prefix))
+	if appErr != nil {
+		return nil, errors.Wrap(appErr, "failed to list keys with prefix from KV store")
+	}
+	return keys, nil
+}

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -409,4 +410,15 @@ func TestMemoryKVStore(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for deleted key")
 	}
+}
+
+// TestMain provides global test setup and cleanup
+func TestMain(m *testing.M) {
+	// Run tests
+	code := m.Run()
+
+	// Ensure all Matrix containers are cleaned up
+	matrixtest.CleanupAllContainers()
+
+	os.Exit(code)
 }


### PR DESCRIPTION
#### Summary
Fixes an issue with room creation and users joining.  Sometimes, after room creation, the join messages from Matrix arrived before the room mapping were written to the DB, and thus unavailable during message processing. This caused existing room members to not join the channel.

Also provides a slash command to re-run the data migrations. 

#### Ticket Link
NONE