### PR TITLE
Do not auto-invite Matrix bridge to all shared channels 

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -193,7 +193,7 @@ func (p *Plugin) registerForSharedChannels() error {
 		PluginID:     "com.mattermost.plugin-matrix-bridge",
 		CreatorID:    creatorID,
 		AutoShareDMs: false,
-		AutoInvited:  true,
+		AutoInvited:  false,
 	}
 
 	remoteID, appErr := p.API.RegisterPluginForSharedChannels(opts)


### PR DESCRIPTION
#### Summary
This PR fixes a bug where the Matrix bridge was being invited to all share channels that are created, and the Matrix bridge display name was shown in the tooltip for all shared channels.

The root cause is a flag used by `mattermost-plugin-msteams-sync` which needed to be invited to all shared channels.  The reason this issue has not been seen before is that the tooltip was implemented only a month ago - long after msteams-sync plugin was widely used.

#### Ticket Link
NONE