### PR TITLE
Fix HTML to Markdown conversion

### DIFF
--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -127,8 +127,8 @@ func (s *BridgeUtils) extractMattermostMetadata(event MatrixEvent) (postID strin
 
 // isHTML checks if content contains HTML tags or entities
 func isHTML(content string) bool {
-	// Check for HTML tags
-	htmlTagRegex := regexp.MustCompile(`<[^>]+>`)
+	// Check for HTML tags - must start with letter or slash and contain valid tag characters
+	htmlTagRegex := regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*[^<>]*>`)
 	if htmlTagRegex.MatchString(content) {
 		return true
 	}

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -127,8 +127,9 @@ func (s *BridgeUtils) extractMattermostMetadata(event MatrixEvent) (postID strin
 
 // isHTML checks if content contains HTML tags or entities
 func isHTML(content string) bool {
-	// Check for HTML tags - must start with letter or slash and contain valid tag characters
-	htmlTagRegex := regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*[^<>]*>`)
+	// Check for HTML tags with proper attribute validation
+	// Matches: <tag>, <tag attr="value">, <tag attr="value" attr2="value2">, </tag>, <tag/>
+	htmlTagRegex := regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*(?:\s+[a-zA-Z-]+(?:="[^"]*")?)*\s*/?>`)
 	if htmlTagRegex.MatchString(content) {
 		return true
 	}

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -155,14 +155,16 @@ func (s *BridgeUtils) extractMatrixMessageContent(event MatrixEvent) string {
 
 	var content string
 
+	// Start with body as the default content
+	if body, ok := event.Content["body"].(string); ok {
+		content = body
+	}
+
 	// Prefer formatted_body if available and different from body
 	if formattedBody, ok := event.Content["formatted_body"].(string); ok {
-		if body, hasBody := event.Content["body"].(string); hasBody {
-			content = body
-			// Only use formatted_body if it's different from body (indicating actual formatting)
-			if formattedBody != body {
-				content = formattedBody
-			}
+		// Only use formatted_body if it's different from body (indicating actual formatting)
+		if formattedBody != content {
+			content = formattedBody
 		}
 	}
 

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -11,6 +11,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	// Compiled regex patterns for HTML detection
+	// htmlTagRegex matches HTML tags with proper attribute validation:
+	// - <tag>, <tag attr="value">, <tag attr="value" attr2="value2">, </tag>, <tag/>
+	// - Allows attributes with optional quoted values
+	// - Rejects invalid attribute names (must start with letter, can contain letters/hyphens)
+	// - Does not validate tag names or attribute values beyond basic syntax
+	htmlTagRegex = regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*(?:\s+[a-zA-Z-]+(?:="[^"]*")?)*\s*/?>`)
+
+	// htmlEntityRegex matches HTML entities like &amp;, &lt;, &#39;, etc.
+	htmlEntityRegex = regexp.MustCompile(`&[a-zA-Z0-9#]+;`)
+)
+
 // ConfigurationGetter interface for getting plugin configuration
 type ConfigurationGetter interface {
 	getConfiguration() *configuration
@@ -127,15 +140,12 @@ func (s *BridgeUtils) extractMattermostMetadata(event MatrixEvent) (postID strin
 
 // isHTML checks if content contains HTML tags or entities
 func isHTML(content string) bool {
-	// Check for HTML tags with proper attribute validation
-	// Matches: <tag>, <tag attr="value">, <tag attr="value" attr2="value2">, </tag>, <tag/>
-	htmlTagRegex := regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*(?:\s+[a-zA-Z-]+(?:="[^"]*")?)*\s*/?>`)
+	// Check for HTML tags using pre-compiled regex
 	if htmlTagRegex.MatchString(content) {
 		return true
 	}
 
-	// Check for HTML entities
-	htmlEntityRegex := regexp.MustCompile(`&[a-zA-Z0-9#]+;`)
+	// Check for HTML entities using pre-compiled regex
 	return htmlEntityRegex.MatchString(content)
 }
 

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -282,6 +282,21 @@ func TestIsHTML(t *testing.T) {
 			content:  "<div class=\"test\">Hello &quot;world&quot;</div>",
 			expected: true,
 		},
+		{
+			name:     "invalid HTML with special characters in attributes",
+			content:  "<div weird!@#$%^&*()stuff>",
+			expected: false,
+		},
+		{
+			name:     "invalid HTML with numeric attribute name",
+			content:  "<tag 123invalid=value>",
+			expected: false,
+		},
+		{
+			name:     "valid data attribute",
+			content:  "<span data-test=\"value\">",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -265,7 +265,7 @@ func TestIsHTML(t *testing.T) {
 		{
 			name:     "text with angle brackets but not HTML",
 			content:  "2 < 3 and 5 > 4",
-			expected: true, // The regex `<[^>]+>` matches "< 3" as a tag
+			expected: false,
 		},
 		{
 			name:     "text with ampersand but not HTML entity",

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -1,0 +1,444 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/matrix"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestExtractMatrixMessageContent(t *testing.T) {
+	// Create test BridgeUtils instance
+	api := &plugintest.API{}
+	api.On("LogDebug", mock.Anything, mock.Anything).Maybe()
+	api.On("LogInfo", mock.Anything, mock.Anything).Maybe()
+	api.On("LogWarn", mock.Anything, mock.Anything).Maybe()
+	api.On("LogError", mock.Anything, mock.Anything).Maybe()
+
+	logger := &testLogger{t: t}
+	kvstore := NewMemoryKVStore()
+	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+
+	config := BridgeUtilsConfig{
+		Logger:       logger,
+		API:          api,
+		KVStore:      kvstore,
+		MatrixClient: matrixClient,
+		RemoteID:     "test-remote",
+	}
+
+	bridgeUtils := NewBridgeUtils(config)
+
+	tests := []struct {
+		name     string
+		event    MatrixEvent
+		expected string
+	}{
+		{
+			name: "message with only body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body": "Hello world",
+				},
+			},
+			expected: "Hello world",
+		},
+		{
+			name: "message with body and identical formatted_body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Hello world",
+					"formatted_body": "Hello world",
+				},
+			},
+			expected: "Hello world",
+		},
+		{
+			name: "message with body and different formatted_body (HTML)",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Hello world",
+					"formatted_body": "Hello <strong>world</strong>",
+					"format":         "org.matrix.custom.html",
+				},
+			},
+			expected: "Hello **world**",
+		},
+		{
+			name: "message with body and different formatted_body (no format field)",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Hello world",
+					"formatted_body": "Hello <em>world</em>",
+				},
+			},
+			expected: "Hello *world*",
+		},
+		{
+			name: "message with only formatted_body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"formatted_body": "Hello <strong>world</strong>",
+					"format":         "org.matrix.custom.html",
+				},
+			},
+			expected: "Hello **world**",
+		},
+		{
+			name: "message with empty content",
+			event: MatrixEvent{
+				Content: map[string]any{},
+			},
+			expected: "",
+		},
+		{
+			name: "message with nil content",
+			event: MatrixEvent{
+				Content: nil,
+			},
+			expected: "",
+		},
+		{
+			name: "message with non-string body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body": 123,
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "message with non-string formatted_body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Hello world",
+					"formatted_body": 123,
+				},
+			},
+			expected: "Hello world",
+		},
+		{
+			name: "message with empty body and formatted_body",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "",
+					"formatted_body": "",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "HTML content without format field",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Plain text",
+					"formatted_body": "HTML with &lt;tags&gt; and entities &amp; stuff",
+				},
+			},
+			expected: "HTML with <tags> and entities & stuff",
+		},
+		{
+			name: "complex HTML formatting",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":           "Complex message",
+					"formatted_body": "<p>This is <strong>bold</strong> and <em>italic</em> text with a <a href=\"https://example.com\">link</a></p>",
+					"format":         "org.matrix.custom.html",
+				},
+			},
+			expected: "This is **bold** and *italic* text with a [link](https://example.com)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := bridgeUtils.extractMatrixMessageContent(tt.event)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsHTMLContent(t *testing.T) {
+	// Create test BridgeUtils instance
+	api := &plugintest.API{}
+	api.On("LogDebug", mock.Anything, mock.Anything).Maybe()
+
+	logger := &testLogger{t: t}
+	kvstore := NewMemoryKVStore()
+	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+
+	config := BridgeUtilsConfig{
+		Logger:       logger,
+		API:          api,
+		KVStore:      kvstore,
+		MatrixClient: matrixClient,
+		RemoteID:     "test-remote",
+	}
+
+	bridgeUtils := NewBridgeUtils(config)
+
+	tests := []struct {
+		name     string
+		content  string
+		event    MatrixEvent
+		expected bool
+	}{
+		{
+			name:     "explicit HTML format",
+			content:  "Hello world",
+			event:    MatrixEvent{Content: map[string]any{"format": "org.matrix.custom.html"}},
+			expected: true,
+		},
+		{
+			name:     "non-HTML format",
+			content:  "Hello world",
+			event:    MatrixEvent{Content: map[string]any{"format": "plain"}},
+			expected: false,
+		},
+		{
+			name:     "no format field with HTML tags",
+			content:  "Hello <strong>world</strong>",
+			event:    MatrixEvent{Content: map[string]any{}},
+			expected: true,
+		},
+		{
+			name:     "no format field with HTML entities",
+			content:  "Hello &amp; world",
+			event:    MatrixEvent{Content: map[string]any{}},
+			expected: true,
+		},
+		{
+			name:     "no format field with plain text",
+			content:  "Hello world",
+			event:    MatrixEvent{Content: map[string]any{}},
+			expected: false,
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			event:    MatrixEvent{Content: map[string]any{}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := bridgeUtils.isHTMLContent(tt.content, tt.event)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "HTML with tags",
+			content:  "Hello <strong>world</strong>",
+			expected: true,
+		},
+		{
+			name:     "HTML with self-closing tags",
+			content:  "Line break<br/>here",
+			expected: true,
+		},
+		{
+			name:     "HTML with entities",
+			content:  "Hello &amp; world",
+			expected: true,
+		},
+		{
+			name:     "HTML with numeric entities",
+			content:  "Hello &#39; world",
+			expected: true,
+		},
+		{
+			name:     "plain text",
+			content:  "Hello world",
+			expected: false,
+		},
+		{
+			name:     "text with angle brackets but not HTML",
+			content:  "2 < 3 and 5 > 4",
+			expected: true, // The regex `<[^>]+>` matches "< 3" as a tag
+		},
+		{
+			name:     "text with ampersand but not HTML entity",
+			content:  "Tom & Jerry",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			content:  "",
+			expected: false,
+		},
+		{
+			name:     "complex HTML",
+			content:  "<div class=\"test\">Hello &quot;world&quot;</div>",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isHTML(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractMattermostMetadata(t *testing.T) {
+	// Create test BridgeUtils instance
+	api := &plugintest.API{}
+	logger := &testLogger{t: t}
+	kvstore := NewMemoryKVStore()
+	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+
+	config := BridgeUtilsConfig{
+		Logger:       logger,
+		API:          api,
+		KVStore:      kvstore,
+		MatrixClient: matrixClient,
+		RemoteID:     "test-remote",
+	}
+
+	bridgeUtils := NewBridgeUtils(config)
+
+	tests := []struct {
+		name             string
+		event            MatrixEvent
+		expectedPostID   string
+		expectedRemoteID string
+	}{
+		{
+			name: "event with both metadata fields",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"mattermost_post_id":   "post123",
+					"mattermost_remote_id": "remote456",
+				},
+			},
+			expectedPostID:   "post123",
+			expectedRemoteID: "remote456",
+		},
+		{
+			name: "event with only post ID",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"mattermost_post_id": "post123",
+				},
+			},
+			expectedPostID:   "post123",
+			expectedRemoteID: "",
+		},
+		{
+			name: "event with only remote ID",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"mattermost_remote_id": "remote456",
+				},
+			},
+			expectedPostID:   "",
+			expectedRemoteID: "remote456",
+		},
+		{
+			name: "event with no metadata",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body": "Hello world",
+				},
+			},
+			expectedPostID:   "",
+			expectedRemoteID: "",
+		},
+		{
+			name: "event with nil content",
+			event: MatrixEvent{
+				Content: nil,
+			},
+			expectedPostID:   "",
+			expectedRemoteID: "",
+		},
+		{
+			name: "event with non-string metadata",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"mattermost_post_id":   123,
+					"mattermost_remote_id": 456,
+				},
+			},
+			expectedPostID:   "",
+			expectedRemoteID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			postID, remoteID := bridgeUtils.extractMattermostMetadata(tt.event)
+			assert.Equal(t, tt.expectedPostID, postID)
+			assert.Equal(t, tt.expectedRemoteID, remoteID)
+		})
+	}
+}
+
+func TestIsGhostUser(t *testing.T) {
+	// Create test BridgeUtils instance
+	api := &plugintest.API{}
+	logger := &testLogger{t: t}
+	kvstore := NewMemoryKVStore()
+	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+
+	config := BridgeUtilsConfig{
+		Logger:       logger,
+		API:          api,
+		KVStore:      kvstore,
+		MatrixClient: matrixClient,
+		RemoteID:     "test-remote",
+	}
+
+	bridgeUtils := NewBridgeUtils(config)
+
+	tests := []struct {
+		name         string
+		matrixUserID string
+		expected     bool
+	}{
+		{
+			name:         "valid ghost user",
+			matrixUserID: "@_mattermost_user123:example.com",
+			expected:     true,
+		},
+		{
+			name:         "regular user",
+			matrixUserID: "@alice:example.com",
+			expected:     false,
+		},
+		{
+			name:         "user with mattermost in name but not ghost",
+			matrixUserID: "@mattermost_fan:example.com",
+			expected:     false,
+		},
+		{
+			name:         "empty string",
+			matrixUserID: "",
+			expected:     false,
+		},
+		{
+			name:         "partial ghost user prefix without trailing underscore",
+			matrixUserID: "@_mattermost",
+			expected:     false, // Missing trailing underscore
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := bridgeUtils.isGhostUser(tt.matrixUserID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/server/matrix_util_test.go
+++ b/server/matrix_util_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	sampleMultilneHTML = `<h3>Suspected Lateral Movement – Relay Switching Behavior Observed</h3>  
+	sampleMultiLineHTML = `<h3>Suspected Lateral Movement – Relay Switching Behavior Observed</h3>  
 <p>We've observed endpoint switching consistent with lateral movement from SATCOM ingress. Traces suggest adversary is exploring multiple exit points across coalition relay nodes.</p>  
 <ul>
 <li>Origin trace tied to COMSAT-4</li>
@@ -20,7 +20,7 @@ const (
 <li>Request trace overlays from JMOD and ASD</li>
 </ul>`
 
-	sampleMultilneMarkdown = `### Suspected Lateral Movement – Relay Switching Behavior Observed
+	sampleMultiLineMarkdown = `### Suspected Lateral Movement – Relay Switching Behavior Observed
 
 We've observed endpoint switching consistent with lateral movement from SATCOM ingress. Traces suggest adversary is exploring multiple exit points across coalition relay nodes.
 
@@ -391,8 +391,8 @@ func TestConvertHTMLToMarkdown(t *testing.T) {
 		},
 		{
 			name:     "multi-line formatted",
-			input:    sampleMultilneHTML,
-			expected: sampleMultilneMarkdown,
+			input:    sampleMultiLineHTML,
+			expected: sampleMultiLineMarkdown,
 		},
 	}
 

--- a/server/matrix_util_test.go
+++ b/server/matrix_util_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/mocks"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sampleMultilneHTML = `<h3>Suspected Lateral Movement – Relay Switching Behavior Observed</h3>  
+<p>We've observed endpoint switching consistent with lateral movement from SATCOM ingress. Traces suggest adversary is exploring multiple exit points across coalition relay nodes.</p>  
+<ul>
+<li>Origin trace tied to COMSAT-4</li>
+<li>Switches across 3 endpoint IPs within 90 seconds</li>
+<li>Echoes techniques seen in the 2023 OPFOR sim</li>
+<li>Request trace overlays from JMOD and ASD</li>
+</ul>`
+
+	sampleMultilneMarkdown = `### Suspected Lateral Movement – Relay Switching Behavior Observed
+
+We've observed endpoint switching consistent with lateral movement from SATCOM ingress. Traces suggest adversary is exploring multiple exit points across coalition relay nodes.
+
+- Origin trace tied to COMSAT-4
+- Switches across 3 endpoint IPs within 90 seconds
+- Echoes techniques seen in the 2023 OPFOR sim
+- Request trace overlays from JMOD and ASD
+`
 )
 
 func TestParseDisplayName(t *testing.T) {
@@ -367,6 +389,11 @@ func TestConvertHTMLToMarkdown(t *testing.T) {
 			input:    "Line 1<br>Line 2<br/>Line 3",
 			expected: "Line 1\n\nLine 2\n\nLine 3", // HTML-to-markdown adds double newlines for br tags
 		},
+		{
+			name:     "multi-line formatted",
+			input:    sampleMultilneHTML,
+			expected: sampleMultilneMarkdown,
+		},
 	}
 
 	for _, tt := range tests {
@@ -378,9 +405,7 @@ func TestConvertHTMLToMarkdown(t *testing.T) {
 			result = strings.TrimSpace(result)
 			expected := strings.TrimSpace(tt.expected)
 
-			if result != expected {
-				t.Errorf("convertHTMLToMarkdown(%q) = %q, want %q", tt.input, result, expected)
-			}
+			require.Equal(t, expected, result)
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
Fixes a bug in the HTML to Markdown conversion which caused HTML to be displayed raw in Mattermost.

Also added unit tests to catch this type of error.

Doesn't support tables at time (but Matix Element [doesn't either yet](https://github.com/element-hq/element-web/issues/9735), unless using HTML directly).

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-64930
