### PR TITLE
Fix html to markdown for edits

### DIFF
--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -168,10 +168,10 @@ func (s *BridgeUtils) extractMatrixMessageContent(event MatrixEvent) string {
 	var content string
 
 	// For edit events, extract content from m.new_content instead of top-level body/formatted_body
-	if relatesTo, exists := event.Content["m.relates_to"].(map[string]any); exists {
-		if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.replace" {
+	if relatesTo, ok := event.Content["m.relates_to"].(map[string]any); ok {
+		if relType, ok := relatesTo["rel_type"].(string); ok && relType == "m.replace" {
 			// This is an edit event - get content from m.new_content
-			if newContent, exists := event.Content["m.new_content"].(map[string]any); exists {
+			if newContent, ok := event.Content["m.new_content"].(map[string]any); ok {
 				// Extract from m.new_content using same logic
 				if body, ok := newContent["body"].(string); ok {
 					content = body

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -167,6 +167,35 @@ func (s *BridgeUtils) extractMatrixMessageContent(event MatrixEvent) string {
 
 	var content string
 
+	// For edit events, extract content from m.new_content instead of top-level body/formatted_body
+	if relatesTo, exists := event.Content["m.relates_to"].(map[string]any); exists {
+		if relType, exists := relatesTo["rel_type"].(string); exists && relType == "m.replace" {
+			// This is an edit event - get content from m.new_content
+			if newContent, exists := event.Content["m.new_content"].(map[string]any); exists {
+				// Extract from m.new_content using same logic
+				if body, ok := newContent["body"].(string); ok {
+					content = body
+				}
+
+				if formattedBody, ok := newContent["formatted_body"].(string); ok {
+					// Only use formatted_body if it's different from body (indicating actual formatting)
+					if formattedBody != content {
+						content = formattedBody
+					}
+				}
+
+				// Create a temporary event for HTML detection with the new_content
+				tempEvent := MatrixEvent{Content: newContent}
+				if s.isHTMLContent(content, tempEvent) {
+					content = s.convertHTMLToMarkdownWithMentions(content, tempEvent)
+				}
+
+				return content
+			}
+		}
+	}
+
+	// For non-edit events, use the existing logic
 	// Start with body as the default content
 	if body, ok := event.Content["body"].(string); ok {
 		content = body

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -184,8 +184,9 @@ func (s *BridgeUtils) extractMatrixMessageContent(event MatrixEvent) string {
 					}
 				}
 
-				// Create a temporary event for HTML detection with the new_content
-				tempEvent := MatrixEvent{Content: newContent}
+				// Create a temporary event for HTML detection with the new_content. Shallow copy the entire event to preserve metadata (m.mentions, etc.)
+				tempEvent := event
+				tempEvent.Content = newContent
 				if s.isHTMLContent(content, tempEvent) {
 					content = s.convertHTMLToMarkdownWithMentions(content, tempEvent)
 				}

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -150,6 +150,73 @@ func TestExtractMatrixMessageContent(t *testing.T) {
 			},
 			expected: "This is **bold** and *italic* text with a [link](https://example.com)",
 		},
+		{
+			name: "edit event with plain text",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":    " * Edited message", // fallback body has /* prefix
+					"msgtype": "m.text",
+					"m.new_content": map[string]any{
+						"msgtype": "m.text",
+						"body":    "Edited message", // actual content without /*
+					},
+					"m.relates_to": map[string]any{
+						"rel_type": "m.replace",
+						"event_id": "$original_event_id:matrix.org",
+					},
+				},
+			},
+			expected: "Edited message",
+		},
+		{
+			name: "edit event with HTML formatting",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":    " * Edited message", // fallback body
+					"msgtype": "m.text",
+					"m.new_content": map[string]any{
+						"msgtype":        "m.text",
+						"body":           "Edited message",
+						"formatted_body": "<p>Edited <strong>message</strong> with <em>formatting</em></p>",
+						"format":         "org.matrix.custom.html",
+					},
+					"m.relates_to": map[string]any{
+						"rel_type": "m.replace",
+						"event_id": "$original_event_id:matrix.org",
+					},
+				},
+			},
+			expected: "Edited **message** with *formatting*",
+		},
+		{
+			name: "edit event without m.new_content (malformed)",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":    " * Edited message",
+					"msgtype": "m.text",
+					"m.relates_to": map[string]any{
+						"rel_type": "m.replace",
+						"event_id": "$original_event_id:matrix.org",
+					},
+				},
+			},
+			expected: " * Edited message", // Falls back to top-level body
+		},
+		{
+			name: "edit event with empty m.new_content",
+			event: MatrixEvent{
+				Content: map[string]any{
+					"body":          " * ",
+					"msgtype":       "m.text",
+					"m.new_content": map[string]any{},
+					"m.relates_to": map[string]any{
+						"rel_type": "m.replace",
+						"event_id": "$original_event_id:matrix.org",
+					},
+				},
+			},
+			expected: "", // Empty content from m.new_content
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### Summary
This PR fixes a bug in the HTML --> markdown conversion code.  This was previously fixed for new posts, but the fix did not cover edits.

Edits coming from Matrix actually use a different field to contain the edited text, requiring a special case. 

#### Ticket Link
NONE