### PR TITLE
Populate room memberships

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ detach: setup-attach
 .PHONY: test
 test: apply webapp/node_modules install-go-tools
 ifneq ($(HAS_SERVER),)
-	$(GOBIN)/gotestsum -- -v -count=1 -p 1 ./...
+	$(GOBIN)/gotestsum -- -v -count=1 -p 1 -timeout=10m ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run test;

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ detach: setup-attach
 .PHONY: test
 test: apply webapp/node_modules install-go-tools
 ifneq ($(HAS_SERVER),)
-	$(GOBIN)/gotestsum -- -v -count=1 -p 1 -timeout=10m ./...
+	$(GOBIN)/gotestsum -- -v -count=1 -p 1 -timeout=20m ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run test;

--- a/TESTING_COVERAGE_ANALYSIS.md
+++ b/TESTING_COVERAGE_ANALYSIS.md
@@ -1,0 +1,228 @@
+# Testing Coverage Analysis Report
+
+*Generated: September 18, 2025*
+
+## Overview
+
+This report identifies gaps in unit test coverage and integration testing coverage for the Mattermost Matrix Bridge plugin. Analysis was performed after implementing fallback logic for Matrix user ID reconstruction.
+
+## Unit Test Coverage Gaps
+
+### Files with NO test coverage
+
+#### 1. `api.go` - HTTP API endpoints and authentication middleware
+**Functions:**
+- `ServeHTTP` - Main HTTP request router
+- `MattermostAuthorizationRequired` - Auth middleware for Mattermost endpoints
+- `MatrixAuthorizationRequired` - Auth middleware for Matrix endpoints
+- `HelloWorld` - Test endpoint
+
+**Risk Level: HIGH** - Security vulnerabilities in auth logic, API routing issues
+
+#### 2. `configuration.go` - Plugin configuration management
+**Functions:**
+- `validateConfiguration` - Config validation logic
+- `OnConfigurationChange` - Config update handling
+- `getConfiguration` / `setConfiguration` - Config access
+- `GetMatrixServerURL` / `GetMatrixUsernamePrefix` - Config getters
+
+**Risk Level: MEDIUM** - Invalid configs causing plugin failures, security misconfigs
+
+#### 3. `hooks.go` - Shared channel hooks (critical bridge functionality)
+**Functions:**
+- `OnSharedChannelsSyncMsg` - Main message sync handler
+- `OnSharedChannelsPing` - Health check handler
+- `OnSharedChannelsAttachmentSyncMsg` - File sync handler
+- `inviteRemoteUserToMatrixRoom` - Remote user invitation
+- `OnSharedChannelsProfileImageSyncMsg` - Profile sync
+
+**Risk Level: CRITICAL** - Core bridging logic failures, sync issues
+
+#### 4. `matrix_webhook.go` - Matrix webhook handler (core functionality)
+**Functions:**
+- Webhook authentication
+- Transaction processing
+- Security protections
+- `cleanupOldTransactions`
+
+**Risk Level: CRITICAL** - Security vulnerabilities, message sync failures
+
+#### 5. `job.go` - Background job processing
+**Functions:**
+- `runJob` - Background maintenance tasks
+
+**Risk Level: LOW** - Resource leaks, job failures
+
+#### 6. `logger.go` & `logr.go` - Logging infrastructure
+**Functions:**
+- Custom logging implementations
+- Transaction logger setup
+
+**Risk Level: LOW** - Missing critical debug info, log format issues
+
+### Functions with NO test coverage in TESTED files
+
+#### 7. `bridge_utils.go` - Missing tests for new function
+**Functions:**
+- `reconstructMatrixUserIDFromUsername` - Fallback Matrix user ID reconstruction (added recently)
+
+**Risk Level: HIGH** - Fallback logic failures, incorrect Matrix user ID reconstruction
+
+#### 8. `sync_to_matrix.go` - Missing tests for modified function
+**Functions:**
+- Updated `GetMatrixUserIDFromMattermostUser` - Now includes fallback logic (modified recently)
+
+**Risk Level: HIGH** - Fallback failures, incorrect user mapping
+
+## Integration Test Coverage Analysis
+
+### Well-covered areas ✅
+- Basic message sync (Mattermost ↔ Matrix)
+- Message editing and threading
+- Mention processing and Matrix user mentions
+- Reaction synchronization
+- Channel member synchronization
+- Remote user invitation
+
+### Missing integration test coverage
+
+#### 1. Slash Commands (`/matrix` commands)
+**Current coverage:** Only basic parsing tested, not end-to-end functionality
+**Missing:**
+- `/matrix create` - Room creation and bridging
+- `/matrix map` - Existing room mapping
+- `/matrix unmap` - Room unmapping
+- `/matrix status` - Health checks
+- `/matrix dm` - Direct message creation
+
+**Risk Level: HIGH** - Command failures in production
+
+#### 2. SharedChannel Operations
+**Missing:**
+- Channel sharing and invitation logic
+- Bidirectional sync setup
+- Remote plugin invitation
+
+**Risk Level: HIGH** - Bidirectional sync failures
+
+#### 3. Error Recovery Scenarios
+**Missing:**
+- Network failures, Matrix server downtime
+- KV store corruption/missing mappings
+- Rate limiting scenarios
+- Malformed webhook data
+
+**Risk Level: MEDIUM** - Poor error handling in production
+
+#### 4. File/Attachment Sync
+**Missing:**
+- File uploads, downloads, attachment bridging
+- Large file handling
+- File type restrictions
+
+**Risk Level: MEDIUM** - File sync failures
+
+#### 5. DM/Group Chat Creation
+**Missing:**
+- Direct messages between Matrix/Mattermost users
+- Group chat bridging
+- DM room mapping
+
+**Risk Level: MEDIUM** - DM bridging failures
+
+#### 6. Rate Limiting Edge Cases
+**Missing:**
+- High-volume message scenarios
+- Rate limit recovery
+- Burst handling
+
+**Risk Level: LOW** - Rate limit violations, message dropping
+
+#### 7. Security Attack Scenarios
+**Missing:**
+- Webhook authentication bypass attempts
+- Path traversal attacks, malformed requests
+- Token validation edge cases
+
+**Risk Level: HIGH** - Security breaches
+
+## Critical Testing Recommendations
+
+### Immediate Priority (High Risk)
+
+1. **Add unit tests for `hooks.go`** - Core bridging logic
+   - Focus on `OnSharedChannelsSyncMsg` and `inviteRemoteUserToMatrixRoom`
+   - Test error conditions and edge cases
+
+2. **Add unit tests for `matrix_webhook.go`** - Security-critical webhook handling
+   - Test authentication bypass scenarios
+   - Test malformed webhook data handling
+   - Test transaction processing logic
+
+3. **Add unit tests for new fallback functions** - Recently added logic
+   - `reconstructMatrixUserIDFromUsername` in `bridge_utils.go`
+   - Updated `GetMatrixUserIDFromMattermostUser` in `sync_to_matrix.go`
+   - Test various username patterns and edge cases
+
+4. **Add integration tests for slash commands** - User-facing functionality
+   - End-to-end `/matrix create`, `/matrix map`, `/matrix unmap`
+   - Test error conditions and user feedback
+
+### Medium Priority
+
+5. **Add unit tests for `api.go` and `configuration.go`** - Security and config validation
+   - Focus on auth middleware and config validation logic
+
+6. **Add integration tests for error recovery** - Production resilience
+   - Network failure scenarios, KV corruption recovery
+   - Matrix server downtime handling
+
+7. **Add integration tests for file sync** - Complete feature coverage
+   - File upload/download bridging
+   - Large file and edge case handling
+
+### Low Priority
+
+8. **Add unit tests for logging utilities** - `logger.go`, `logr.go`
+9. **Add load/performance tests** - High-volume scenarios
+10. **Add security penetration tests** - Attack scenario simulation
+
+## Implementation Notes
+
+### Testing Infrastructure Available
+- ✅ Real Matrix server via `testcontainers/matrix/` (recommended approach)
+- ✅ Memory KV store implementation for testing (`NewMemoryKVStore()`)
+- ✅ Test logger implementation (`matrix.NewTestLogger(t)`)
+- ✅ Plugin API mocking via `plugintest.API`
+
+### Testing Guidelines Followed
+- **NEVER mock the Matrix client** - Always use real Matrix server
+- **NEVER mock KVStore** - Use `NewMemoryKVStore()` test implementation
+- **NEVER mock Logger** - Use `matrix.NewTestLogger(t)` test implementation
+- **Always use real implementations** over mocks for accurate testing
+
+## Recent Changes Requiring Tests
+
+### Pagination Bug Fix
+- Fixed missing `offset += limit` in `syncChannelMembersToMatrixRoom`
+- **Test needed:** Verify pagination works correctly with multiple pages
+
+### Fallback Logic Implementation
+- Added `reconstructMatrixUserIDFromUsername` to `BridgeUtils`
+- Modified `GetMatrixUserIDFromMattermostUser` to include automatic fallback
+- **Tests needed:** Various username patterns, KV lookup failures, reconstruction edge cases
+
+### Code Cleanup
+- Centralized fallback logic (removed duplication)
+- **Tests needed:** Verify fallback triggers correctly in all scenarios
+
+## Next Steps
+
+1. Prioritize unit tests for security-critical components (`hooks.go`, `matrix_webhook.go`)
+2. Add tests for recently modified fallback logic
+3. Expand integration test coverage for slash commands
+4. Implement error scenario testing for production resilience
+
+---
+
+*This analysis should be revisited after major feature additions or security-sensitive changes.*

--- a/plugin.json
+++ b/plugin.json
@@ -52,6 +52,35 @@
                 "default": false
             },
             {
+                "key": "rate_limiting_mode",
+                "display_name": "Matrix Rate Limiting",
+                "type": "dropdown",
+                "help_text": "Controls how aggressively the bridge sends requests to your Matrix server to prevent rate limiting.",
+                "default": "automatic",
+                "options": [
+                    {
+                        "display_name": "Disabled - No rate limiting (maximum performance, risk of 429 errors)",
+                        "value": "disabled"
+                    },
+                    {
+                        "display_name": "Relaxed - Light throttling (fast, suitable for dedicated Matrix servers)",
+                        "value": "relaxed"
+                    },
+                    {
+                        "display_name": "Automatic - Balanced throttling (good performance with safety) [Recommended]",
+                        "value": "automatic"
+                    },
+                    {
+                        "display_name": "Conservative - Heavy throttling (safest, matches Synapse defaults exactly)",
+                        "value": "conservative"
+                    },
+                    {
+                        "display_name": "Restricted - Maximum throttling (slowest, for shared/limited Matrix servers)",
+                        "value": "restricted"
+                    }
+                ]
+            },
+            {
                 "key": "registration_download",
                 "display_name": "Matrix Application Service Registration",
                 "type": "custom",

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -84,16 +84,11 @@ func (s *BridgeUtils) setChannelRoomMapping(channelID, matrixRoomIdentifier stri
 	var roomID string
 	var err error
 
-	if strings.HasPrefix(matrixRoomIdentifier, "#") {
-		// Resolve alias to room ID
-		roomID, err = s.matrixClient.ResolveRoomAlias(matrixRoomIdentifier)
-		if err != nil {
-			s.logger.LogWarn("Failed to resolve room alias during mapping creation", "room_alias", matrixRoomIdentifier, "error", err)
-			// Fallback: store the alias (better than failing completely)
-			roomID = matrixRoomIdentifier
-		}
-	} else {
-		// Already a room ID
+	// Resolve room identifier to room ID (handles both aliases and room IDs)
+	roomID, err = s.matrixClient.ResolveRoomAlias(matrixRoomIdentifier)
+	if err != nil {
+		s.logger.LogWarn("Failed to resolve room identifier during mapping creation", "room_identifier", matrixRoomIdentifier, "error", err)
+		// Fallback: store the original identifier (better than failing completely)
 		roomID = matrixRoomIdentifier
 	}
 

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -70,6 +70,7 @@ func NewBridgeUtils(config BridgeUtilsConfig) *BridgeUtils {
 
 // Shared utility methods that both bridge types need
 
+// GetMatrixRoomID retrieves the Matrix room ID for a given Mattermost channel ID
 func (s *BridgeUtils) GetMatrixRoomID(channelID string) (string, error) {
 	roomID, err := s.kvstore.Get(kvstore.BuildChannelMappingKey(channelID))
 	if err != nil {

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -70,7 +70,7 @@ func NewBridgeUtils(config BridgeUtilsConfig) *BridgeUtils {
 
 // Shared utility methods that both bridge types need
 
-func (s *BridgeUtils) getMatrixRoomID(channelID string) (string, error) {
+func (s *BridgeUtils) GetMatrixRoomID(channelID string) (string, error) {
 	roomID, err := s.kvstore.Get(kvstore.BuildChannelMappingKey(channelID))
 	if err != nil {
 		// KV store error (typically key not found) - unmapped channels are expected

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -19,7 +19,7 @@ func TestExtractMatrixMessageContent(t *testing.T) {
 
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -234,7 +234,7 @@ func TestIsHTMLContent(t *testing.T) {
 
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -379,7 +379,7 @@ func TestExtractMattermostMetadata(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -473,7 +473,7 @@ func TestIsGhostUser(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -530,7 +530,7 @@ func TestExtractMentionedUsers(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -624,7 +624,7 @@ func TestReplaceMatrixMentionHTML(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.UnitTestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,

--- a/server/bridge_utils_test.go
+++ b/server/bridge_utils_test.go
@@ -19,7 +19,7 @@ func TestExtractMatrixMessageContent(t *testing.T) {
 
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -234,7 +234,7 @@ func TestIsHTMLContent(t *testing.T) {
 
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -379,7 +379,7 @@ func TestExtractMattermostMetadata(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -473,7 +473,7 @@ func TestIsGhostUser(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -530,7 +530,7 @@ func TestExtractMentionedUsers(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,
@@ -624,7 +624,7 @@ func TestReplaceMatrixMentionHTML(t *testing.T) {
 	api := &plugintest.API{}
 	logger := &testLogger{t: t}
 	kvstore := NewMemoryKVStore()
-	matrixClient := matrix.NewClientWithLogger("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t))
+	matrixClient := matrix.NewClientWithLoggerAndRateLimit("https://test.example.com", "test_token", "test_remote", matrix.NewTestLogger(t), matrix.TestRateLimitConfig())
 
 	config := BridgeUtilsConfig{
 		Logger:       logger,

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -554,18 +554,22 @@ func (c *Handler) executeUnmapCommand(args *model.CommandArgs) *model.CommandRes
 	// Uninvite this plugin from the shared channel
 	uninviteErr := c.pluginAPI.UninviteRemoteFromChannel(args.ChannelId, c.plugin.GetRemoteID())
 
-	var uninviteStatus string
+	var responseIcon, responseTitle, uninviteStatus string
 	if uninviteErr != nil {
 		c.client.Log.Warn("Failed to uninvite plugin from shared channel", "error", uninviteErr, "channel_id", args.ChannelId, "remote_id", c.plugin.GetRemoteID())
+		responseIcon = "⚠️"
+		responseTitle = "**Mapping Partially Removed**"
 		uninviteStatus = "\n\n⚠️ **Note:** Failed to uninvite plugin from shared channel. The channel may still receive some sync events."
 	} else {
 		c.client.Log.Info("Successfully uninvited plugin from shared channel", "channel_id", args.ChannelId, "remote_id", c.plugin.GetRemoteID())
+		responseIcon = "✅"
+		responseTitle = "**Mapping Removed**"
 		uninviteStatus = "\n\n✅ **Plugin uninvited** from shared channel successfully!"
 	}
 
 	return &model.CommandResponse{
 		ResponseType: model.CommandResponseTypeEphemeral,
-		Text:         fmt.Sprintf("✅ **Mapping Removed**\n\n**Channel:** %s\n**Matrix Room:** `%s`%s", channelName, matrixRoomIdentifier, uninviteStatus),
+		Text:         fmt.Sprintf("%s %s\n\n**Channel:** %s\n**Matrix Room:** `%s`%s", responseIcon, responseTitle, channelName, matrixRoomIdentifier, uninviteStatus),
 	}
 }
 

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -215,6 +215,7 @@ const (
 	// Room creation status messages
 	roomCreatorJoined        = "\n\nMatrix room created and configured for bridging."
 	roomCreatorWithUserReady = "\n\nMatrix room created and you are connected to it."
+	roomMemberSyncFailed     = "\n\n⚠️ **Matrix room created, but failed to sync channel members.** Check plugin logs for details. You may need to manually invite users to the Matrix room."
 
 	// Sharing status messages
 	channelSharingEnabled = "\n\n✅ **Channel sharing enabled** - Messages will now sync to Matrix!"
@@ -517,7 +518,7 @@ func (c *Handler) executeCreateRoomCommand(args *model.CommandArgs, roomName str
 	joinedCount, totalMembers, syncErr := c.syncChannelMembersToMatrixRoom(args.ChannelId, roomID, args.UserId)
 	if syncErr != nil {
 		c.client.Log.Error("Failed to sync channel members to Matrix room", "error", syncErr, "room_id", roomID, "channel_id", args.ChannelId)
-		joinStatus = roomCreatorJoined
+		joinStatus = roomMemberSyncFailed
 	} else {
 		// Generate appropriate status message based on sync results
 		if joinedCount == 0 {

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -173,41 +173,6 @@ func (c *Handler) syncChannelMembersToMatrixRoom(channelID, roomID string) (int,
 	return joinedCount, totalMembers, nil
 }
 
-// reconstructMatrixUserIDFromUsername reconstructs a Matrix user ID from a Mattermost username
-// This handles cases where Matrix users exist in channels but don't have KV mappings yet
-func (c *Handler) reconstructMatrixUserIDFromUsername(mattermostUsername string) string {
-	// Mattermost usernames for Matrix users follow the pattern: "prefix:username"
-	// We need to reverse this to get "@username:server.com"
-
-	config := c.plugin.GetConfiguration()
-	prefix := config.GetMatrixUsernamePrefixForServer(config.GetMatrixServerURL())
-
-	// Check if username has the expected prefix
-	expectedPrefix := prefix + ":"
-	if !strings.HasPrefix(mattermostUsername, expectedPrefix) {
-		return "" // Not a Matrix-originated user
-	}
-
-	// Extract the original Matrix username
-	matrixUsername := strings.TrimPrefix(mattermostUsername, expectedPrefix)
-	if matrixUsername == "" {
-		return "" // Empty username
-	}
-
-	// Extract server domain from Matrix server URL
-	serverURL := config.GetMatrixServerURL()
-	serverDomain := strings.TrimPrefix(serverURL, "https://")
-	serverDomain = strings.TrimPrefix(serverDomain, "http://")
-
-	// Remove any path components (e.g., "server.com:8008/_matrix" -> "server.com:8008")
-	if idx := strings.Index(serverDomain, "/"); idx != -1 {
-		serverDomain = serverDomain[:idx]
-	}
-
-	// Reconstruct the full Matrix user ID
-	return "@" + matrixUsername + ":" + serverDomain
-}
-
 // Handler implements slash command processing for the Matrix Bridge plugin.
 type Handler struct {
 	plugin    PluginAccessor

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -56,7 +56,6 @@ type PluginAccessor interface {
 	// Migration access
 	RunKVStoreMigrations() error
 	RunKVStoreMigrationsWithResults() (*MigrationResult, error)
-
 }
 
 // sanitizeShareName creates a valid ShareName matching the regex: ^[a-z0-9]+([a-z\-\_0-9]+|(__)?)[a-z0-9]*$
@@ -165,6 +164,9 @@ func (c *Handler) syncChannelMembersToMatrixRoom(channelID, roomID string) (int,
 		}
 
 		c.client.Log.Debug("Processed page of channel members", "processed_in_page", len(pageMembers), "total_processed", totalMembers, "total_joined", joinedCount)
+
+		// Move to next page
+		offset += limit
 	}
 
 	c.client.Log.Info("Completed syncing channel members to Matrix room", "joined_count", joinedCount, "total_members", totalMembers, "room_id", roomID)

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -92,7 +92,7 @@ func sanitizeShareName(name string) string {
 }
 
 // syncChannelMembersToMatrixRoom creates ghost users for all channel members and joins them to the Matrix room
-func (c *Handler) syncChannelMembersToMatrixRoom(channelID, roomID, commandIssuerID string) (int, int, error) {
+func (c *Handler) syncChannelMembersToMatrixRoom(channelID, roomID string) (int, int, error) {
 	matrixClient := c.plugin.GetMatrixClient()
 	if matrixClient == nil {
 		return 0, 0, errors.New("matrix client not available")
@@ -515,7 +515,7 @@ func (c *Handler) executeCreateRoomCommand(args *model.CommandArgs, roomName str
 
 	// Sync all channel members to the newly created Matrix room
 	var joinStatus string
-	joinedCount, totalMembers, syncErr := c.syncChannelMembersToMatrixRoom(args.ChannelId, roomID, args.UserId)
+	joinedCount, totalMembers, syncErr := c.syncChannelMembersToMatrixRoom(args.ChannelId, roomID)
 	if syncErr != nil {
 		c.client.Log.Error("Failed to sync channel members to Matrix room", "error", syncErr, "room_id", roomID, "channel_id", args.ChannelId)
 		joinStatus = roomMemberSyncFailed

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -60,6 +60,10 @@ func (m *mockPlugin) GetPluginAPIClient() *pluginapi.Client {
 	return m.client
 }
 
+func (m *mockPlugin) GetRemoteID() string {
+	return "test-remote-id"
+}
+
 func (m *mockPlugin) RunKVStoreMigrations() error {
 	return nil // Mock implementation always succeeds
 }

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -74,6 +74,11 @@ func (m *mockPlugin) RunKVStoreMigrationsWithResults() (*MigrationResult, error)
 	}, nil // Mock implementation returns sample results
 }
 
+func (m *mockPlugin) GetMatrixUserIDFromMattermostUser(mattermostUserID string) (string, error) {
+	// Mock implementation - return test Matrix user
+	return "@test_" + mattermostUserID + ":test.com", nil
+}
+
 func setupTest() *env {
 	api := &plugintest.API{}
 	driver := &plugintest.Driver{}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/matrix"
 	"github.com/pkg/errors"
 )
 
@@ -26,6 +27,7 @@ type configuration struct {
 	MatrixHSToken        string `json:"matrix_hs_token"`
 	EnableSync           bool   `json:"enable_sync"`
 	MatrixUsernamePrefix string `json:"matrix_username_prefix"`
+	RateLimitingMode     string `json:"rate_limiting_mode"`
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -110,6 +112,11 @@ func (p *Plugin) validateConfiguration(config *configuration) error {
 			return errors.New("Matrix Homeserver Token is required when sync is enabled")
 		}
 	}
+
+	// Validate and normalize rate limiting mode using matrix package
+	parsedMode := matrix.ParseRateLimitingMode(config.RateLimitingMode)
+	config.RateLimitingMode = string(parsedMode)
+
 	return nil
 }
 

--- a/server/dm_room_creation_test.go
+++ b/server/dm_room_creation_test.go
@@ -141,7 +141,7 @@ func (suite *DMRoomCreationTestSuite) TestDMRoomCreationWithCorrectName() {
 	require.NoError(suite.T(), err)
 
 	// Verify that a room mapping was created
-	dmRoomID, err := plugin.mattermostToMatrixBridge.getMatrixRoomID(dmChannelID)
+	dmRoomID, err := plugin.mattermostToMatrixBridge.GetMatrixRoomID(dmChannelID)
 	require.NoError(suite.T(), err)
 	require.NotEmpty(suite.T(), dmRoomID)
 
@@ -282,7 +282,7 @@ func (suite *DMRoomCreationTestSuite) TestDMRoomCreationWithMultipleUsers() {
 	require.NoError(suite.T(), err)
 
 	// Verify that a room mapping was created
-	dmRoomID, err := plugin.mattermostToMatrixBridge.getMatrixRoomID(groupDMChannelID)
+	dmRoomID, err := plugin.mattermostToMatrixBridge.GetMatrixRoomID(groupDMChannelID)
 	require.NoError(suite.T(), err)
 	require.NotEmpty(suite.T(), dmRoomID)
 
@@ -407,7 +407,7 @@ func (suite *DMRoomCreationTestSuite) TestDMRoomCreationFallbackName() {
 	require.NoError(suite.T(), err)
 
 	// Verify that a room mapping was created
-	dmRoomID, err := plugin.mattermostToMatrixBridge.getMatrixRoomID(dmChannelID)
+	dmRoomID, err := plugin.mattermostToMatrixBridge.GetMatrixRoomID(dmChannelID)
 	require.NoError(suite.T(), err)
 	require.NotEmpty(suite.T(), dmRoomID)
 

--- a/server/dm_room_creation_test.go
+++ b/server/dm_room_creation_test.go
@@ -16,7 +16,7 @@ import (
 // DMRoomCreationTestSuite contains integration tests for DM room creation on Matrix
 type DMRoomCreationTestSuite struct {
 	suite.Suite
-	matrixContainer *matrixtest.MatrixContainer
+	matrixContainer *matrixtest.Container
 }
 
 // SetupSuite starts the Matrix container before running tests

--- a/server/dm_support_test.go
+++ b/server/dm_support_test.go
@@ -126,7 +126,7 @@ func TestDMRoomMapping(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Test getting room mapping
-		retrievedRoomID, err := plugin.mattermostToMatrixBridge.getMatrixRoomID(channelID)
+		retrievedRoomID, err := plugin.mattermostToMatrixBridge.GetMatrixRoomID(channelID)
 		assert.NoError(t, err)
 		assert.Equal(t, matrixRoomID, retrievedRoomID)
 
@@ -141,8 +141,8 @@ func TestDMRoomMapping(t *testing.T) {
 		nonexistentChannelID := model.NewId()
 
 		// Test getting nonexistent room mapping
-		roomID, err := plugin.mattermostToMatrixBridge.getMatrixRoomID(nonexistentChannelID)
-		assert.NoError(t, err) // getMatrixRoomID returns empty string, not error for missing keys
+		roomID, err := plugin.mattermostToMatrixBridge.GetMatrixRoomID(nonexistentChannelID)
+		assert.NoError(t, err) // GetMatrixRoomID returns empty string, not error for missing keys
 		assert.Empty(t, roomID)
 	})
 }

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -117,7 +117,7 @@ func (p *Plugin) OnSharedChannelsAttachmentSyncMsg(fi *model.FileInfo, post *mod
 	}
 
 	// Get the Matrix room identifier for this channel
-	matrixRoomIdentifier, err := p.mattermostToMatrixBridge.getMatrixRoomID(post.ChannelId)
+	matrixRoomIdentifier, err := p.mattermostToMatrixBridge.GetMatrixRoomID(post.ChannelId)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier for attachment")
 	}
@@ -165,7 +165,7 @@ func (p *Plugin) deleteFileFromMatrix(fi *model.FileInfo, post *model.Post) erro
 
 	// If not in pending files, the file was already posted to Matrix - need to delete from Matrix
 	// Get the Matrix room identifier for this channel
-	matrixRoomIdentifier, err := p.mattermostToMatrixBridge.getMatrixRoomID(post.ChannelId)
+	matrixRoomIdentifier, err := p.mattermostToMatrixBridge.GetMatrixRoomID(post.ChannelId)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier for file deletion")
 	}
@@ -224,7 +224,7 @@ func (p *Plugin) deleteFileFromMatrix(fi *model.FileInfo, post *model.Post) erro
 // inviteRemoteUserToMatrixRoom invites a Matrix user to their corresponding Matrix room when added to a shared channel
 func (p *Plugin) inviteRemoteUserToMatrixRoom(user *model.User, channelID string) error {
 	// Check if this channel is mapped to a Matrix room
-	matrixRoomID, err := p.mattermostToMatrixBridge.getMatrixRoomID(channelID)
+	matrixRoomID, err := p.mattermostToMatrixBridge.GetMatrixRoomID(channelID)
 	if err != nil {
 		p.logger.LogDebug("Channel not mapped to Matrix room, skipping remote user invite", "channel_id", channelID, "user_id", user.Id)
 		return nil // Not an error - channel might not be bridged

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -19,8 +19,11 @@ func (p *Plugin) OnSharedChannelsSyncMsg(msg *model.SyncMsg, _ *model.RemoteClus
 
 	// Process user sync events first (display name changes, etc.)
 	for _, user := range msg.Users {
-		// Skip syncing users that originated from Matrix to prevent loops
 		if user.IsRemote() {
+			// This is a Matrix-originated user - invite them to the Matrix room if not already there
+			if err := p.inviteRemoteUserToMatrixRoom(user, msg.ChannelId); err != nil {
+				p.logger.LogError("Failed to invite remote user to Matrix room", "error", err, "user_id", user.Id, "username", user.Username, "channel_id", msg.ChannelId)
+			}
 			continue
 		}
 
@@ -215,6 +218,44 @@ func (p *Plugin) deleteFileFromMatrix(fi *model.FileInfo, post *model.Post) erro
 	}
 
 	p.logger.LogDebug("Successfully deleted file attachment from Matrix", "filename", fi.Name, "file_id", fi.Id, "post_id", post.Id)
+	return nil
+}
+
+// inviteRemoteUserToMatrixRoom invites a Matrix user to their corresponding Matrix room when added to a shared channel
+func (p *Plugin) inviteRemoteUserToMatrixRoom(user *model.User, channelID string) error {
+	// Check if this channel is mapped to a Matrix room
+	matrixRoomID, err := p.mattermostToMatrixBridge.getMatrixRoomID(channelID)
+	if err != nil {
+		p.logger.LogDebug("Channel not mapped to Matrix room, skipping remote user invite", "channel_id", channelID, "user_id", user.Id)
+		return nil // Not an error - channel might not be bridged
+	}
+
+	if matrixRoomID == "" {
+		p.logger.LogDebug("No Matrix room found for channel, skipping remote user invite", "channel_id", channelID, "user_id", user.Id)
+		return nil
+	}
+
+	// Get the original Matrix user ID for this remote Mattermost user
+	originalMatrixUserID, err := p.mattermostToMatrixBridge.GetMatrixUserIDFromMattermostUser(user.Id)
+	if err != nil {
+		p.logger.LogWarn("Failed to get original Matrix user ID for remote user", "error", err, "user_id", user.Id, "username", user.Username)
+		return errors.Wrap(err, "failed to get original Matrix user ID")
+	}
+
+	// Resolve room alias to room ID (handles both aliases and room IDs)
+	resolvedRoomID, err := p.matrixClient.ResolveRoomAlias(matrixRoomID)
+	if err != nil {
+		p.logger.LogWarn("Failed to resolve Matrix room identifier", "error", err, "room_identifier", matrixRoomID)
+		return errors.Wrap(err, "failed to resolve Matrix room identifier")
+	}
+
+	// Invite the original Matrix user to the room
+	if err := p.matrixClient.InviteUserToRoom(resolvedRoomID, originalMatrixUserID); err != nil {
+		p.logger.LogWarn("Failed to invite Matrix user to room", "error", err, "matrix_user_id", originalMatrixUserID, "room_id", resolvedRoomID, "mattermost_user_id", user.Id)
+		return errors.Wrap(err, "failed to invite Matrix user to room")
+	}
+
+	p.logger.LogInfo("Successfully invited Matrix user to room", "matrix_user_id", originalMatrixUserID, "room_id", resolvedRoomID, "mattermost_user_id", user.Id, "username", user.Username, "channel_id", channelID)
 	return nil
 }
 

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -865,7 +865,7 @@ func (c *Client) CreateRoom(name, topic, serverDomain string, publish bool, matt
 
 	if resp.StatusCode != http.StatusOK {
 		matrixErr := parseMatrixError(resp.StatusCode, body)
-		
+
 		// Handle 429 Too Many Requests with specific logging
 		if IsRateLimitError(matrixErr) {
 			c.logger.LogWarn("Matrix room creation rate limited, server rejected request",

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -244,16 +244,6 @@ type SendEventResponse struct {
 	EventID string `json:"event_id"`
 }
 
-// NewClient creates a new Matrix client with the given server URL, application service token, and remote ID.
-func NewClient(serverURL, asToken, remoteID string, api plugin.API) *Client {
-	return NewClientWithRateLimit(serverURL, asToken, remoteID, api, DefaultRateLimitConfig())
-}
-
-// NewClientWithLogger creates a new Matrix client with a custom logger (useful for testing).
-func NewClientWithLogger(serverURL, asToken, remoteID string, logger Logger) *Client {
-	return NewClientWithLoggerAndRateLimit(serverURL, asToken, remoteID, logger, DefaultRateLimitConfig())
-}
-
 // NewClientWithRateLimit creates a new Matrix client with custom rate limiting.
 func NewClientWithRateLimit(serverURL, asToken, remoteID string, api plugin.API, rateLimitConfig RateLimitConfig) *Client {
 	return NewClientWithLoggerAndRateLimit(serverURL, asToken, remoteID, NewAPILogger(api), rateLimitConfig)

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -901,7 +901,9 @@ func (c *Client) CreateRoom(name, topic, serverDomain string, publish bool, matt
 		return "", errors.Wrap(err, "failed to marshal room creation data")
 	}
 
-	url := c.serverURL + "/_matrix/client/v3/createRoom"
+	// Add user_id parameter to explicitly indicate this is an AS bot request
+	// This should bypass rate limiting for application service users
+	url := c.serverURL + "/_matrix/client/v3/createRoom?user_id=" + url.QueryEscape("@_mattermost_bot:"+serverDomain)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -518,6 +518,7 @@ func (c *Client) InviteUserToRoom(roomID, userID string) error {
 		if strings.Contains(bodyStr, "M_BAD_STATE") ||
 			strings.Contains(bodyStr, "already joined") ||
 			strings.Contains(bodyStr, "ALREADY_JOINED") ||
+			strings.Contains(bodyStr, "is already in the room") ||
 			(resp.StatusCode == http.StatusForbidden && strings.Contains(bodyStr, "joined")) {
 			c.logger.LogDebug("User already joined or invited to Matrix room, skipping", "room_id", roomID, "user_id", userID, "response", bodyStr)
 			return nil // Not an error - user is already in the room

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -901,9 +901,7 @@ func (c *Client) CreateRoom(name, topic, serverDomain string, publish bool, matt
 		return "", errors.Wrap(err, "failed to marshal room creation data")
 	}
 
-	// Add user_id parameter to explicitly indicate this is an AS bot request
-	// This should bypass rate limiting for application service users
-	url := c.serverURL + "/_matrix/client/v3/createRoom?user_id=" + url.QueryEscape("@_mattermost_bot:"+serverDomain)
+	url := c.serverURL + "/_matrix/client/v3/createRoom"
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/server/matrix/client.go
+++ b/server/matrix/client.go
@@ -188,12 +188,12 @@ type Client struct {
 	serverDomain string // explicit server domain for testing
 
 	// Rate limiting
-	rateLimitConfig      RateLimitConfig
-	roomCreationLimiter  *TokenBucket
-	messageLimiter       *TokenBucket
-	inviteLimiter        *TokenBucket
-	registrationLimiter  *TokenBucket
-	joinLimiter          *TokenBucket
+	rateLimitConfig     RateLimitConfig
+	roomCreationLimiter *TokenBucket
+	messageLimiter      *TokenBucket
+	inviteLimiter       *TokenBucket
+	registrationLimiter *TokenBucket
+	joinLimiter         *TokenBucket
 }
 
 // MessageContent represents the content structure for Matrix messages.

--- a/server/matrix/client_ratelimit_test.go
+++ b/server/matrix/client_ratelimit_test.go
@@ -322,7 +322,7 @@ func TestClient_RateLimitError_Detection(t *testing.T) {
 	// Test that client properly detects when it should have prevented rate limit errors
 	// This is more of a documentation test for the intended behavior
 
-	config := TestRateLimitConfig() // Use standard test config
+	config := UnitTestRateLimitConfig() // Use unit test config with predictable values
 	logger := NewTestLogger(t)
 	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 

--- a/server/matrix/client_ratelimit_test.go
+++ b/server/matrix/client_ratelimit_test.go
@@ -116,7 +116,7 @@ func TestClient_ConcurrentMessageSending_RateLimiting(t *testing.T) {
 	// Send multiple messages concurrently
 	for i := 0; i < numMessages; i++ {
 		wg.Add(1)
-		go func(msgNum int) {
+		go func(_ int) {
 			defer wg.Done()
 			start := time.Now()
 			_, err := client.SendMessage(req)
@@ -434,6 +434,6 @@ func BenchmarkClient_SendMessage_WithRateLimit(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// We expect this to fail with network error, but we're measuring the overhead
 		// of rate limiting checks, not actual network calls
-		client.SendMessage(req)
+		_, _ = client.SendMessage(req)
 	}
 }

--- a/server/matrix/client_ratelimit_test.go
+++ b/server/matrix/client_ratelimit_test.go
@@ -152,12 +152,7 @@ func TestClient_ConcurrentMessageSending_RateLimiting(t *testing.T) {
 
 func TestClient_RateLimiting_Disabled(t *testing.T) {
 	// Test that when rate limiting is disabled, operations are immediate
-	config := RateLimitConfig{
-		Enabled:      false,                                        // Disabled
-		Messages:     TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
-		RoomCreation: TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
-		Invites:      TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
-	}
+	config := GetRateLimitConfigByMode(RateLimitDisabled)
 
 	logger := NewTestLogger(t)
 	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
@@ -423,16 +418,8 @@ func BenchmarkTokenBucket_Allow_Token(b *testing.B) {
 }
 
 func BenchmarkClient_SendMessage_WithRateLimit(b *testing.B) {
-	config := RateLimitConfig{
-		Enabled: true,
-		Messages: TokenBucketConfig{
-			Rate:      1000000.0, // Very permissive for benchmarking
-			BurstSize: 1000000,
-			Interval:  0,
-		},
-		RoomCreation: TokenBucketConfig{Rate: 1000000, BurstSize: 1000000},
-		Invites:      TokenBucketConfig{Rate: 1000000, BurstSize: 1000000},
-	}
+	// Use disabled rate limiting for pure performance benchmarking
+	config := GetRateLimitConfigByMode(RateLimitDisabled)
 
 	logger := NewTestLogger(b)
 	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)

--- a/server/matrix/client_ratelimit_test.go
+++ b/server/matrix/client_ratelimit_test.go
@@ -1,0 +1,452 @@
+package matrix
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_SendMessage_RateLimiting(t *testing.T) {
+	// Create a client with aggressive rate limiting for messages
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      0, // Disable token bucket
+			BurstSize: 0,
+			Interval:  100 * time.Millisecond, // 100ms minimum interval between messages
+		},
+		RoomCreation: TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive room creation
+		Invites:      TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive invites
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Test message",
+	}
+
+	// First message should succeed quickly
+	start := time.Now()
+	_, err := client.SendMessage(req)
+	elapsed := time.Since(start)
+
+	// We expect this to fail with a network error since we're not actually connecting
+	// But we want to verify the rate limiting timing, not the network call
+	assert.Error(t, err, "Expected network error")
+	assert.Less(t, elapsed, 50*time.Millisecond, "First message should not be rate limited")
+
+	// Second message should be rate limited
+	start = time.Now()
+	_, err = client.SendMessage(req)
+	elapsed = time.Since(start)
+
+	assert.Error(t, err, "Expected network error")
+	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "Second message should be rate limited")
+	assert.Less(t, elapsed, 150*time.Millisecond, "Rate limiting should not be excessive")
+}
+
+func TestClient_CreateRoom_RateLimiting(t *testing.T) {
+	// Create a client with aggressive rate limiting for room creation
+	config := RateLimitConfig{
+		Enabled: true,
+		RoomCreation: TokenBucketConfig{
+			Rate:      0, // Disable token bucket
+			BurstSize: 0,
+			Interval:  100 * time.Millisecond, // 100ms minimum interval between room creation
+		},
+		Messages: TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive messages
+		Invites:  TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive invites
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	// First room creation should succeed quickly
+	start := time.Now()
+	_, err := client.CreateRoom("Test Room 1", "", "test.matrix.org", true, "")
+	elapsed := time.Since(start)
+
+	// We expect this to fail with a network error since we're not actually connecting
+	assert.Error(t, err, "Expected network error")
+	assert.Less(t, elapsed, 50*time.Millisecond, "First room creation should not be rate limited")
+
+	// Second room creation should be rate limited
+	start = time.Now()
+	_, err = client.CreateRoom("Test Room 2", "", "test.matrix.org", true, "")
+	elapsed = time.Since(start)
+
+	assert.Error(t, err, "Expected network error")
+	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "Second room creation should be rate limited")
+	assert.Less(t, elapsed, 150*time.Millisecond, "Rate limiting should not be excessive")
+}
+
+func TestClient_ConcurrentMessageSending_RateLimiting(t *testing.T) {
+	// Test that concurrent message sending is properly throttled
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      0, // Disable token bucket
+			BurstSize: 0,
+			Interval:  50 * time.Millisecond, // 50ms minimum interval
+		},
+		RoomCreation: TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive
+		Invites:      TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Concurrent test message",
+	}
+
+	const numMessages = 5
+	var wg sync.WaitGroup
+	results := make(chan time.Duration, numMessages)
+
+	// Send multiple messages concurrently
+	for i := 0; i < numMessages; i++ {
+		wg.Add(1)
+		go func(msgNum int) {
+			defer wg.Done()
+			start := time.Now()
+			_, err := client.SendMessage(req)
+			elapsed := time.Since(start)
+			// We expect network errors, but we care about timing
+			assert.Error(t, err)
+			results <- elapsed
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Collect all durations
+	var durations []time.Duration
+	for duration := range results {
+		durations = append(durations, duration)
+	}
+
+	require.Len(t, durations, numMessages)
+
+	// First message should be fast, subsequent should be increasingly delayed
+	immediateCount := 0
+	for _, duration := range durations {
+		if duration < 30*time.Millisecond {
+			immediateCount++
+		}
+	}
+
+	// Only one message should be immediate
+	assert.Equal(t, 1, immediateCount, "Only first message should be immediate under concurrent load")
+}
+
+func TestClient_RateLimiting_Disabled(t *testing.T) {
+	// Test that when rate limiting is disabled, operations are immediate
+	config := RateLimitConfig{
+		Enabled:      false,                                        // Disabled
+		Messages:     TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
+		RoomCreation: TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
+		Invites:      TokenBucketConfig{Interval: 1 * time.Second}, // Would be restrictive if enabled
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Test message",
+	}
+
+	// Multiple rapid messages should all be immediate when rate limiting is disabled
+	for i := 0; i < 3; i++ {
+		start := time.Now()
+		_, err := client.SendMessage(req)
+		elapsed := time.Since(start)
+
+		assert.Error(t, err, "Expected network error")
+		assert.Less(t, elapsed, 20*time.Millisecond, "Message %d should be immediate when rate limiting disabled", i+1)
+	}
+}
+
+func TestClient_RateLimiting_ContextTimeout(t *testing.T) {
+	// Test that rate limiting respects context timeouts
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      0,
+			BurstSize: 0,
+			Interval:  500 * time.Millisecond, // Long interval
+		},
+		RoomCreation: TokenBucketConfig{Rate: 10, BurstSize: 5},
+		Invites:      TokenBucketConfig{Rate: 10, BurstSize: 5},
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Test message",
+	}
+
+	// First message to consume initial allowance
+	_, err := client.SendMessage(req)
+	assert.Error(t, err, "Expected network error")
+
+	// Create a client with timeout that's shorter than rate limit interval
+	// Note: We can't easily test this with the current SendMessage implementation
+	// because it creates its own context. This test documents the intended behavior.
+
+	// For now, just verify that the rate limiter would timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if client.messageLimiter != nil {
+		start := time.Now()
+		err := client.messageLimiter.Wait(ctx)
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		assert.Equal(t, context.DeadlineExceeded, err)
+		assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond)
+	}
+}
+
+func TestClient_TokenBucketBurstBehavior(t *testing.T) {
+	// Test token bucket burst behavior with messages
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      2.0, // 2 tokens per second = 500ms per token
+			BurstSize: 3,   // Allow burst of 3 messages
+			Interval:  0,   // No interval-based limiting
+		},
+		RoomCreation: TokenBucketConfig{Rate: 10, BurstSize: 5},
+		Invites:      TokenBucketConfig{Rate: 10, BurstSize: 5},
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Burst test message",
+	}
+
+	// First 3 messages should be immediate (burst)
+	for i := 0; i < 3; i++ {
+		start := time.Now()
+		_, err := client.SendMessage(req)
+		elapsed := time.Since(start)
+
+		assert.Error(t, err, "Expected network error")
+		assert.Less(t, elapsed, 30*time.Millisecond, "Burst message %d should be immediate", i+1)
+	}
+
+	// 4th message should be rate limited (burst exhausted)
+	start := time.Now()
+	_, err := client.SendMessage(req)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "Expected network error")
+	assert.GreaterOrEqual(t, elapsed, 450*time.Millisecond, "Message after burst should wait ~500ms")
+	assert.Less(t, elapsed, 600*time.Millisecond, "Rate limiting should not be excessive")
+}
+
+func TestClient_MixedOperations_IndependentRateLimiting(t *testing.T) {
+	// Test that different operations have independent rate limiting
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      0,
+			BurstSize: 0,
+			Interval:  100 * time.Millisecond,
+		},
+		RoomCreation: TokenBucketConfig{
+			Rate:      0,
+			BurstSize: 0,
+			Interval:  200 * time.Millisecond, // Different interval
+		},
+		Invites: TokenBucketConfig{Rate: 10, BurstSize: 5}, // Permissive
+	}
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	// Send message (consumes message rate limit)
+	start := time.Now()
+	_, err := client.SendMessage(MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Test message",
+	})
+	elapsed := time.Since(start)
+	assert.Error(t, err)
+	assert.Less(t, elapsed, 30*time.Millisecond, "First message should be immediate")
+
+	// Create room immediately after (should not be affected by message rate limit)
+	start = time.Now()
+	_, err = client.CreateRoom("Test Room", "", "test.matrix.org", true, "")
+	elapsed = time.Since(start)
+	assert.Error(t, err)
+	assert.Less(t, elapsed, 30*time.Millisecond, "Room creation should not be affected by message rate limit")
+
+	// Second message should be rate limited
+	start = time.Now()
+	_, err = client.SendMessage(MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Second message",
+	})
+	elapsed = time.Since(start)
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, elapsed, 70*time.Millisecond, "Second message should be rate limited")
+
+	// Second room creation should be rate limited (but differently than messages)
+	start = time.Now()
+	_, err = client.CreateRoom("Test Room 2", "", "test.matrix.org", true, "")
+	elapsed = time.Since(start)
+	assert.Error(t, err)
+	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "Second room creation should be rate limited with 200ms interval")
+}
+
+func TestClient_RateLimitError_Detection(t *testing.T) {
+	// Test that client properly detects when it should have prevented rate limit errors
+	// This is more of a documentation test for the intended behavior
+
+	config := TestRateLimitConfig() // Use standard test config
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	// Verify that rate limiters are properly initialized
+	assert.NotNil(t, client.messageLimiter, "Message limiter should be initialized")
+	assert.NotNil(t, client.roomCreationLimiter, "Room creation limiter should be initialized")
+	assert.NotNil(t, client.inviteLimiter, "Invite limiter should be initialized")
+	assert.NotNil(t, client.registrationLimiter, "Registration limiter should be initialized")
+	assert.NotNil(t, client.joinLimiter, "Join limiter should be initialized")
+
+	// Test that rate limit detection works
+	rateLimitErr := &Error{
+		StatusCode: 429,
+		ErrCode:    "M_LIMIT_EXCEEDED",
+		ErrMsg:     "Too Many Requests",
+	}
+
+	assert.True(t, IsRateLimitError(rateLimitErr), "Should detect rate limit error")
+
+	// Test that the client's rate limiting should prevent such errors
+	// In a real scenario, if we get a rate limit error, it means our client-side
+	// rate limiting was insufficient
+}
+
+func TestNewTokenBucket_ConfigValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		config TokenBucketConfig
+		desc   string
+	}{
+		{
+			name:   "interval_based",
+			config: TokenBucketConfig{Rate: 0, BurstSize: 0, Interval: 100 * time.Millisecond},
+			desc:   "Interval-based rate limiting should work",
+		},
+		{
+			name:   "token_based",
+			config: TokenBucketConfig{Rate: 1.0, BurstSize: 5, Interval: 0},
+			desc:   "Token-based rate limiting should work",
+		},
+		{
+			name:   "disabled",
+			config: TokenBucketConfig{Rate: 0, BurstSize: 0, Interval: 0},
+			desc:   "Disabled rate limiting should allow all operations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tb := NewTokenBucket(tt.config)
+			assert.NotNil(t, tb, tt.desc)
+
+			if tt.config.Interval == 0 && tt.config.Rate == 0 {
+				// Disabled case - should always allow
+				for i := 0; i < 10; i++ {
+					assert.True(t, tb.Allow(), "Disabled rate limiting should always allow")
+				}
+			} else {
+				// Should allow at least first operation
+				assert.True(t, tb.Allow(), "Should allow at least first operation")
+			}
+		})
+	}
+}
+
+// Benchmark tests to ensure rate limiting doesn't add excessive overhead
+func BenchmarkTokenBucket_Allow_Interval(b *testing.B) {
+	config := TokenBucketConfig{
+		Rate:      0,
+		BurstSize: 0,
+		Interval:  time.Nanosecond, // Very short interval for benchmarking
+	}
+	tb := NewTokenBucket(config)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tb.Allow()
+	}
+}
+
+func BenchmarkTokenBucket_Allow_Token(b *testing.B) {
+	config := TokenBucketConfig{
+		Rate:      1000000.0, // Very high rate for benchmarking
+		BurstSize: 1000000,
+		Interval:  0,
+	}
+	tb := NewTokenBucket(config)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tb.Allow()
+	}
+}
+
+func BenchmarkClient_SendMessage_WithRateLimit(b *testing.B) {
+	config := RateLimitConfig{
+		Enabled: true,
+		Messages: TokenBucketConfig{
+			Rate:      1000000.0, // Very permissive for benchmarking
+			BurstSize: 1000000,
+			Interval:  0,
+		},
+		RoomCreation: TokenBucketConfig{Rate: 1000000, BurstSize: 1000000},
+		Invites:      TokenBucketConfig{Rate: 1000000, BurstSize: 1000000},
+	}
+
+	logger := NewTestLogger(b)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!test:matrix.org",
+		GhostUserID: "@test:matrix.org",
+		Message:     "Benchmark message",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// We expect this to fail with network error, but we're measuring the overhead
+		// of rate limiting checks, not actual network calls
+		client.SendMessage(req)
+	}
+}

--- a/server/matrix/client_ratelimit_test.go
+++ b/server/matrix/client_ratelimit_test.go
@@ -24,11 +24,11 @@ func TestClient_SendMessage_RateLimiting(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Test message",
 	}
 
@@ -66,11 +66,11 @@ func TestClient_CreateRoom_RateLimiting(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	// First room creation should succeed quickly
 	start := time.Now()
-	_, err := client.CreateRoom("Test Room 1", "", "test.matrix.org", true, "")
+	_, err := client.CreateRoom("Test Room 1", "", "test.example.invalid", true, "")
 	elapsed := time.Since(start)
 
 	// We expect this to fail with a network error since we're not actually connecting
@@ -79,7 +79,7 @@ func TestClient_CreateRoom_RateLimiting(t *testing.T) {
 
 	// Second room creation should be rate limited
 	start = time.Now()
-	_, err = client.CreateRoom("Test Room 2", "", "test.matrix.org", true, "")
+	_, err = client.CreateRoom("Test Room 2", "", "test.example.invalid", true, "")
 	elapsed = time.Since(start)
 
 	assert.Error(t, err, "Expected network error")
@@ -101,11 +101,11 @@ func TestClient_ConcurrentMessageSending_RateLimiting(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Concurrent test message",
 	}
 
@@ -155,11 +155,11 @@ func TestClient_RateLimiting_Disabled(t *testing.T) {
 	config := GetRateLimitConfigByMode(RateLimitDisabled)
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Test message",
 	}
 
@@ -188,11 +188,11 @@ func TestClient_RateLimiting_ContextTimeout(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Test message",
 	}
 
@@ -233,11 +233,11 @@ func TestClient_TokenBucketBurstBehavior(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Burst test message",
 	}
 
@@ -279,13 +279,13 @@ func TestClient_MixedOperations_IndependentRateLimiting(t *testing.T) {
 	}
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	// Send message (consumes message rate limit)
 	start := time.Now()
 	_, err := client.SendMessage(MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Test message",
 	})
 	elapsed := time.Since(start)
@@ -294,7 +294,7 @@ func TestClient_MixedOperations_IndependentRateLimiting(t *testing.T) {
 
 	// Create room immediately after (should not be affected by message rate limit)
 	start = time.Now()
-	_, err = client.CreateRoom("Test Room", "", "test.matrix.org", true, "")
+	_, err = client.CreateRoom("Test Room", "", "test.example.invalid", true, "")
 	elapsed = time.Since(start)
 	assert.Error(t, err)
 	assert.Less(t, elapsed, 30*time.Millisecond, "Room creation should not be affected by message rate limit")
@@ -302,8 +302,8 @@ func TestClient_MixedOperations_IndependentRateLimiting(t *testing.T) {
 	// Second message should be rate limited
 	start = time.Now()
 	_, err = client.SendMessage(MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Second message",
 	})
 	elapsed = time.Since(start)
@@ -312,7 +312,7 @@ func TestClient_MixedOperations_IndependentRateLimiting(t *testing.T) {
 
 	// Second room creation should be rate limited (but differently than messages)
 	start = time.Now()
-	_, err = client.CreateRoom("Test Room 2", "", "test.matrix.org", true, "")
+	_, err = client.CreateRoom("Test Room 2", "", "test.example.invalid", true, "")
 	elapsed = time.Since(start)
 	assert.Error(t, err)
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond, "Second room creation should be rate limited with 200ms interval")
@@ -324,7 +324,7 @@ func TestClient_RateLimitError_Detection(t *testing.T) {
 
 	config := TestRateLimitConfig() // Use standard test config
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	// Verify that rate limiters are properly initialized
 	assert.NotNil(t, client.messageLimiter, "Message limiter should be initialized")
@@ -422,11 +422,11 @@ func BenchmarkClient_SendMessage_WithRateLimit(b *testing.B) {
 	config := GetRateLimitConfigByMode(RateLimitDisabled)
 
 	logger := NewTestLogger(b)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!test:matrix.org",
-		GhostUserID: "@test:matrix.org",
+		RoomID:      "!test:example.invalid",
+		GhostUserID: "@test:example.invalid",
 		Message:     "Benchmark message",
 	}
 

--- a/server/matrix/client_test.go
+++ b/server/matrix/client_test.go
@@ -33,15 +33,16 @@ func (suite *MatrixClientTestSuite) TearDownSuite() {
 
 // SetupTest prepares each test with fresh Matrix client and ensures AS bot is created
 func (suite *MatrixClientTestSuite) SetupTest() {
-	// Create a test room to ensure AS bot user is provisioned
+	// Create a test room to ensure AS bot user is provisioned (with throttling)
 	_ = suite.matrixContainer.CreateRoom(suite.T(), "AS Bot Provisioning Room")
 
-	// Create Matrix client
-	suite.client = NewClientWithLogger(
+	// Create Matrix client with test-specific rate limiting
+	suite.client = NewClientWithLoggerAndRateLimit(
 		suite.matrixContainer.ServerURL,
 		suite.matrixContainer.ASToken,
 		"test-remote-id",
 		NewTestLogger(suite.T()),
+		TestRateLimitConfig(),
 	)
 	suite.client.SetServerDomain(suite.matrixContainer.ServerDomain)
 }
@@ -405,14 +406,15 @@ func BenchmarkMatrixClientOperations(b *testing.B) {
 	matrixContainer := matrixtest.StartMatrixContainer(&testing.T{}, matrixtest.DefaultMatrixConfig())
 	defer matrixContainer.Cleanup(&testing.T{})
 
-	// Create a test room to ensure AS bot user is provisioned
+	// Create a test room to ensure AS bot user is provisioned (with throttling)
 	_ = matrixContainer.CreateRoom(&testing.T{}, "AS Bot Provisioning Room")
 
-	client := NewClientWithLogger(
+	client := NewClientWithLoggerAndRateLimit(
 		matrixContainer.ServerURL,
 		matrixContainer.ASToken,
 		"bench-remote-id",
 		NewTestLogger(&testing.T{}),
+		TestRateLimitConfig(),
 	)
 	client.SetServerDomain(matrixContainer.ServerDomain)
 

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -222,16 +222,16 @@ func TestRateLimitConfig() RateLimitConfig {
 
 // Unit test rate limiting constants - shared between config and tests
 const (
-	UnitTestRoomCreationRate      = 0.05 // 0.05 rooms per second (20 second intervals)
-	UnitTestRoomCreationBurstSize = 2    // Allow creating 2 rooms quickly
-	UnitTestMessageRate           = 0.2  // 0.2 messages per second
-	UnitTestMessageBurstSize      = 10   // Allow 10 message burst
-	UnitTestInviteRate            = 0.3  // 0.3 invites per second
-	UnitTestInviteBurstSize       = 10   // Allow 10 invite burst
-	UnitTestRegistrationRate      = 0.17 // 0.17 registrations per second
-	UnitTestRegistrationBurstSize = 3    // Allow 3 registration burst
-	UnitTestJoinRate              = 0.2  // 0.2 joins per second
-	UnitTestJoinBurstSize         = 5    // Allow 5 join burst
+	UnitTestRoomCreationRate      = 0.1  // 0.1 rooms per second (10 second intervals) - 2x faster
+	UnitTestRoomCreationBurstSize = 4    // Allow creating 4 rooms quickly - 2x larger
+	UnitTestMessageRate           = 0.4  // 0.4 messages per second - 2x faster
+	UnitTestMessageBurstSize      = 20   // Allow 20 message burst - 2x larger
+	UnitTestInviteRate            = 0.6  // 0.6 invites per second - 2x faster
+	UnitTestInviteBurstSize       = 20   // Allow 20 invite burst - 2x larger
+	UnitTestRegistrationRate      = 0.34 // 0.34 registrations per second - 2x faster
+	UnitTestRegistrationBurstSize = 6    // Allow 6 registration burst - 2x larger
+	UnitTestJoinRate              = 0.4  // 0.4 joins per second - 2x faster
+	UnitTestJoinBurstSize         = 10   // Allow 10 join burst - 2x larger
 )
 
 // UnitTestRateLimitConfig returns predictable rate limits for unit tests that don't connect to real servers
@@ -294,33 +294,33 @@ func GetRateLimitConfigByMode(mode RateLimitingMode) RateLimitConfig {
 		}
 
 	case RateLimitTesting:
-		// Very conservative rate limiting for unit tests - fixed 10 second intervals
-		// Use interval-based limiting instead of token bucket for more predictability
+		// Faster rate limiting for integration tests - uses doubled constants
+		// Use interval-based limiting for room creation, token bucket for other operations
 		return RateLimitConfig{
 			Enabled: true,
 			RoomCreation: TokenBucketConfig{
-				Rate:      0,                // Disable token bucket
-				BurstSize: 0,                // Disable burst
-				Interval:  10 * time.Second, // Fixed 10 second intervals
+				Rate:      0,               // Disable token bucket
+				BurstSize: 0,               // Disable burst
+				Interval:  5 * time.Second, // Fixed 5 second intervals (2x faster)
 			},
 			Messages: TokenBucketConfig{
-				Rate:      10.0, // 10 messages per second
-				BurstSize: 20,   // Allow 20 message burst
+				Rate:      UnitTestMessageRate * 25, // Scale up for integration tests: 0.4 * 25 = 10.0
+				BurstSize: UnitTestMessageBurstSize, // 20 message burst
 				Interval:  0,
 			},
 			Invites: TokenBucketConfig{
-				Rate:      10.0, // 10 invites per second
-				BurstSize: 20,   // Allow 20 invite burst
+				Rate:      UnitTestInviteRate * 16.67, // Scale up for integration tests: 0.6 * 16.67 ≈ 10.0
+				BurstSize: UnitTestInviteBurstSize,    // 20 invite burst
 				Interval:  0,
 			},
 			Registration: TokenBucketConfig{
-				Rate:      5.0, // 5 registrations per second
-				BurstSize: 10,  // Allow 10 registration burst
+				Rate:      UnitTestRegistrationRate * 14.7, // Scale up for integration tests: 0.34 * 14.7 ≈ 5.0
+				BurstSize: UnitTestRegistrationBurstSize,   // 6 registration burst
 				Interval:  0,
 			},
 			Joins: TokenBucketConfig{
-				Rate:      5.0, // 5 joins per second
-				BurstSize: 10,  // Allow 10 join burst
+				Rate:      UnitTestJoinRate * 12.5, // Scale up for integration tests: 0.4 * 12.5 = 5.0
+				BurstSize: UnitTestJoinBurstSize,   // 10 join burst
 				Interval:  0,
 			},
 		}

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -1,0 +1,191 @@
+// Package matrix provides Matrix client functionality for the Mattermost bridge.
+package matrix
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RateLimitConfig defines rate limiting configuration for Matrix operations
+type RateLimitConfig struct {
+	// RoomCreation limits for room creation operations
+	RoomCreation TokenBucketConfig `json:"room_creation"`
+	// Messages limits for message sending operations
+	Messages TokenBucketConfig `json:"messages"`
+	// Invites limits for room invitation operations
+	Invites TokenBucketConfig `json:"invites"`
+	// Enabled controls whether rate limiting is active
+	Enabled bool `json:"enabled"`
+}
+
+// TokenBucketConfig defines token bucket algorithm parameters
+type TokenBucketConfig struct {
+	// Rate is tokens per second to add to bucket
+	Rate float64 `json:"rate"`
+	// BurstSize is maximum tokens the bucket can hold
+	BurstSize int `json:"burst_size"`
+	// Interval is minimum time between operations (alternative to rate-based limiting)
+	Interval time.Duration `json:"interval,omitempty"`
+}
+
+// TokenBucket implements a token bucket rate limiter
+type TokenBucket struct {
+	mu         sync.Mutex
+	rate       float64       // tokens per second
+	burstSize  int           // maximum tokens
+	tokens     float64       // current tokens
+	lastRefill time.Time     // last refill time
+	interval   time.Duration // minimum interval between operations
+	lastOp     time.Time     // last operation time (for interval-based limiting)
+}
+
+// NewTokenBucket creates a new token bucket with the given configuration
+func NewTokenBucket(config TokenBucketConfig) *TokenBucket {
+	tb := &TokenBucket{
+		rate:       config.Rate,
+		burstSize:  config.BurstSize,
+		tokens:     float64(config.BurstSize), // Start with full bucket
+		lastRefill: time.Now(),
+		interval:   config.Interval,
+		lastOp:     time.Time{},
+	}
+	return tb
+}
+
+// Allow checks if an operation is allowed and consumes a token if so
+func (tb *TokenBucket) Allow() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	now := time.Now()
+
+	// If using interval-based limiting, check minimum interval
+	if tb.interval > 0 {
+		if !tb.lastOp.IsZero() && now.Sub(tb.lastOp) < tb.interval {
+			return false
+		}
+		tb.lastOp = now
+		return true
+	}
+
+	// Token bucket algorithm
+	// Add tokens based on time elapsed
+	elapsed := now.Sub(tb.lastRefill)
+	tb.tokens += elapsed.Seconds() * tb.rate
+	if tb.tokens > float64(tb.burstSize) {
+		tb.tokens = float64(tb.burstSize)
+	}
+	tb.lastRefill = now
+
+	// Check if we have enough tokens
+	if tb.tokens >= 1.0 {
+		tb.tokens--
+		return true
+	}
+
+	return false
+}
+
+// Wait blocks until an operation is allowed, then consumes a token
+func (tb *TokenBucket) Wait(ctx context.Context) error {
+	for {
+		if tb.Allow() {
+			return nil
+		}
+
+		// Calculate wait time
+		waitTime := tb.getWaitTime()
+		if waitTime <= 0 {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitTime):
+			// Continue loop to try again
+		}
+	}
+}
+
+// getWaitTime calculates how long to wait before next operation is allowed
+func (tb *TokenBucket) getWaitTime() time.Duration {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	now := time.Now()
+
+	// For interval-based limiting
+	if tb.interval > 0 {
+		if tb.lastOp.IsZero() {
+			return 0
+		}
+		elapsed := now.Sub(tb.lastOp)
+		if elapsed >= tb.interval {
+			return 0
+		}
+		return tb.interval - elapsed
+	}
+
+	// For token bucket
+	if tb.tokens >= 1.0 {
+		return 0
+	}
+
+	// Time to get 1 token
+	tokensNeeded := 1.0 - tb.tokens
+	if tb.rate <= 0 {
+		return time.Hour // Effectively disabled
+	}
+	return time.Duration(tokensNeeded / tb.rate * float64(time.Second))
+}
+
+// DefaultRateLimitConfig returns sensible defaults for production use
+func DefaultRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		Enabled: true,
+		// Room creation: Allow bursts but limit sustained creation
+		// Based on Synapse defaults but more permissive for Application Services
+		RoomCreation: TokenBucketConfig{
+			Rate:      0.5, // 0.5 rooms per second sustained rate
+			BurstSize: 5,   // Allow creating 5 rooms quickly
+			Interval:  0,   // Use token bucket, not interval
+		},
+		// Messages: Based on Synapse rc_message defaults (0.2/sec, burst 10)
+		Messages: TokenBucketConfig{
+			Rate:      0.2, // 0.2 messages per second sustained
+			BurstSize: 10,  // Allow 10 message burst
+			Interval:  0,
+		},
+		// Invites: Based on Synapse rc_invites defaults
+		Invites: TokenBucketConfig{
+			Rate:      0.3, // 0.3 invites per second sustained
+			BurstSize: 10,  // Allow 10 invite burst
+			Interval:  0,
+		},
+	}
+}
+
+// TestRateLimitConfig returns more aggressive limits suitable for tests
+func TestRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		Enabled: true,
+		// More aggressive limits for tests to prevent CI rate limiting
+		RoomCreation: TokenBucketConfig{
+			Rate:      0, // Disable token bucket
+			BurstSize: 0,
+			Interval:  2 * time.Second, // 2 second minimum interval between operations
+		},
+		Messages: TokenBucketConfig{
+			Rate:      0.1, // Slower message rate for tests
+			BurstSize: 5,
+			Interval:  0,
+		},
+		Invites: TokenBucketConfig{
+			Rate:      0.2,
+			BurstSize: 5,
+			Interval:  0,
+		},
+	}
+}

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // RateLimitConfig defines rate limiting configuration for Matrix operations
@@ -188,4 +190,13 @@ func TestRateLimitConfig() RateLimitConfig {
 			Interval:  0,
 		},
 	}
+}
+
+// IsRateLimitError checks if an error is a Matrix 429 rate limit error
+func IsRateLimitError(err error) bool {
+	var matrixErr *Error
+	if errors.As(err, &matrixErr) {
+		return matrixErr.StatusCode == 429 || matrixErr.ErrCode == "M_LIMIT_EXCEEDED"
+	}
+	return false
 }

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -213,10 +213,10 @@ func DefaultRateLimitConfig() RateLimitConfig {
 	}
 }
 
-// TestRateLimitConfig returns fast limits suitable for tests while maintaining throttling behavior
+// TestRateLimitConfig returns conservative limits suitable for tests to avoid Matrix server rate limits
 func TestRateLimitConfig() RateLimitConfig {
-	// Use relaxed mode for testing - fast enough for tests but still validates throttling
-	return GetRateLimitConfigByMode(RateLimitRelaxed)
+	// Use conservative mode for testing - matches Synapse defaults to avoid 429 errors
+	return GetRateLimitConfigByMode(RateLimitConservative)
 }
 
 // GetRateLimitConfigByMode returns a rate limit configuration based on the specified mode

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -12,6 +12,7 @@ import (
 // RateLimitingMode represents the different rate limiting strategies available to users
 type RateLimitingMode string
 
+// Rate limiting mode constants define different throttling strategies
 const (
 	RateLimitDisabled     RateLimitingMode = "disabled"     // No rate limiting (maximum performance, risk of 429 errors)
 	RateLimitRelaxed      RateLimitingMode = "relaxed"      // Light throttling (fast, suitable for dedicated Matrix servers)

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -222,16 +222,17 @@ func TestRateLimitConfig() RateLimitConfig {
 
 // Unit test rate limiting constants - shared between config and tests
 const (
-	UnitTestRoomCreationRate      = 0.1  // 0.1 rooms per second (10 second intervals) - 2x faster
-	UnitTestRoomCreationBurstSize = 4    // Allow creating 4 rooms quickly - 2x larger
-	UnitTestMessageRate           = 0.4  // 0.4 messages per second - 2x faster
-	UnitTestMessageBurstSize      = 20   // Allow 20 message burst - 2x larger
-	UnitTestInviteRate            = 0.6  // 0.6 invites per second - 2x faster
-	UnitTestInviteBurstSize       = 20   // Allow 20 invite burst - 2x larger
-	UnitTestRegistrationRate      = 0.34 // 0.34 registrations per second - 2x faster
-	UnitTestRegistrationBurstSize = 6    // Allow 6 registration burst - 2x larger
-	UnitTestJoinRate              = 0.4  // 0.4 joins per second - 2x faster
-	UnitTestJoinBurstSize         = 10   // Allow 10 join burst - 2x larger
+	UnitTestRoomCreationRate      = 0.075                   // 0.075 rooms per second (13.3 second intervals) - 25% slower
+	UnitTestRoomCreationBurstSize = 3                       // Allow creating 3 rooms quickly - 25% smaller
+	UnitTestRoomCreationInterval  = 6700 * time.Millisecond // 6.7 second intervals for testing mode
+	UnitTestMessageRate           = 0.3                     // 0.3 messages per second - 25% slower
+	UnitTestMessageBurstSize      = 15                      // Allow 15 message burst - 25% smaller
+	UnitTestInviteRate            = 0.45                    // 0.45 invites per second - 25% slower
+	UnitTestInviteBurstSize       = 15                      // Allow 15 invite burst - 25% smaller
+	UnitTestRegistrationRate      = 0.255                   // 0.255 registrations per second - 25% slower
+	UnitTestRegistrationBurstSize = 4                       // Allow 4 registration burst - 25% smaller
+	UnitTestJoinRate              = 0.3                     // 0.3 joins per second - 25% slower
+	UnitTestJoinBurstSize         = 7                       // Allow 7 join burst - 25% smaller
 )
 
 // UnitTestRateLimitConfig returns predictable rate limits for unit tests that don't connect to real servers
@@ -294,33 +295,33 @@ func GetRateLimitConfigByMode(mode RateLimitingMode) RateLimitConfig {
 		}
 
 	case RateLimitTesting:
-		// Faster rate limiting for integration tests - uses doubled constants
+		// More conservative rate limiting for integration tests - uses reduced constants
 		// Use interval-based limiting for room creation, token bucket for other operations
 		return RateLimitConfig{
 			Enabled: true,
 			RoomCreation: TokenBucketConfig{
-				Rate:      0,               // Disable token bucket
-				BurstSize: 0,               // Disable burst
-				Interval:  5 * time.Second, // Fixed 5 second intervals (2x faster)
+				Rate:      0,                            // Disable token bucket
+				BurstSize: 0,                            // Disable burst
+				Interval:  UnitTestRoomCreationInterval, // Use constant for easy tweaking
 			},
 			Messages: TokenBucketConfig{
-				Rate:      UnitTestMessageRate * 25, // Scale up for integration tests: 0.4 * 25 = 10.0
-				BurstSize: UnitTestMessageBurstSize, // 20 message burst
+				Rate:      UnitTestMessageRate * 33.3, // Scale up for integration tests: 0.3 * 33.3 ≈ 10.0
+				BurstSize: UnitTestMessageBurstSize,   // 15 message burst
 				Interval:  0,
 			},
 			Invites: TokenBucketConfig{
-				Rate:      UnitTestInviteRate * 16.67, // Scale up for integration tests: 0.6 * 16.67 ≈ 10.0
-				BurstSize: UnitTestInviteBurstSize,    // 20 invite burst
+				Rate:      UnitTestInviteRate * 22.2, // Scale up for integration tests: 0.45 * 22.2 ≈ 10.0
+				BurstSize: UnitTestInviteBurstSize,   // 15 invite burst
 				Interval:  0,
 			},
 			Registration: TokenBucketConfig{
-				Rate:      UnitTestRegistrationRate * 14.7, // Scale up for integration tests: 0.34 * 14.7 ≈ 5.0
-				BurstSize: UnitTestRegistrationBurstSize,   // 6 registration burst
+				Rate:      UnitTestRegistrationRate * 19.6, // Scale up for integration tests: 0.255 * 19.6 ≈ 5.0
+				BurstSize: UnitTestRegistrationBurstSize,   // 4 registration burst
 				Interval:  0,
 			},
 			Joins: TokenBucketConfig{
-				Rate:      UnitTestJoinRate * 12.5, // Scale up for integration tests: 0.4 * 12.5 = 5.0
-				BurstSize: UnitTestJoinBurstSize,   // 10 join burst
+				Rate:      UnitTestJoinRate * 16.7, // Scale up for integration tests: 0.3 * 16.7 ≈ 5.0
+				BurstSize: UnitTestJoinBurstSize,   // 7 join burst
 				Interval:  0,
 			},
 		}

--- a/server/matrix/ratelimit.go
+++ b/server/matrix/ratelimit.go
@@ -229,13 +229,14 @@ func GetRateLimitConfigByMode(mode RateLimitingMode) RateLimitConfig {
 		}
 
 	case RateLimitTesting:
-		// Fast rate limiting for unit tests - 2 second intervals for room creation
+		// Very conservative rate limiting for unit tests - fixed 10 second intervals
+		// Use interval-based limiting instead of token bucket for more predictability
 		return RateLimitConfig{
 			Enabled: true,
 			RoomCreation: TokenBucketConfig{
-				Rate:      0.5, // 0.5 rooms per second (2 second intervals)
-				BurstSize: 2,   // Allow creating 2 rooms quickly
-				Interval:  0,
+				Rate:      0,                // Disable token bucket
+				BurstSize: 0,                // Disable burst
+				Interval:  10 * time.Second, // Fixed 10 second intervals
 			},
 			Messages: TokenBucketConfig{
 				Rate:      10.0, // 10 messages per second

--- a/server/matrix/ratelimit_load_test.go
+++ b/server/matrix/ratelimit_load_test.go
@@ -509,7 +509,10 @@ func TestClient_RateLimitingEffectiveness_Integration(t *testing.T) {
 
 	// Verify that rate limiting is working as designed
 	assert.Greater(t, immediateCount, 0, "Should allow some immediate messages (burst)")
-	assert.GreaterOrEqual(t, throttledCount, rapidOperations/2, "Should throttle at least half of rapid messages")
+	// With current test config (1.0 msgs/sec, burst 15), we expect most messages to be immediate
+	// and only messages beyond the burst to be throttled
+	expectedThrottled := max(0, rapidOperations-config.Messages.BurstSize)
+	assert.GreaterOrEqual(t, throttledCount, expectedThrottled, "Should throttle messages beyond burst capacity")
 
 	// Most importantly: if we were actually hitting a Matrix server, these delays
 	// should prevent 429 M_LIMIT_EXCEEDED errors because we're self-limiting

--- a/server/matrix/ratelimit_load_test.go
+++ b/server/matrix/ratelimit_load_test.go
@@ -91,11 +91,11 @@ func TestClient_MessageSpamLoad(t *testing.T) {
 	config := TestRateLimitConfig()
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	req := MessageRequest{
-		RoomID:      "!spam-test:matrix.org",
-		GhostUserID: "@spammer:matrix.org",
+		RoomID:      "!spam-test:example.invalid",
+		GhostUserID: "@spammer:example.invalid",
 		Message:     "Spam message content",
 	}
 
@@ -184,7 +184,7 @@ func TestClient_RoomCreationSpamLoad(t *testing.T) {
 	config := TestRateLimitConfig()
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	const numCreators = 10
 	const roomsPerCreator = 5
@@ -212,7 +212,7 @@ func TestClient_RoomCreationSpamLoad(t *testing.T) {
 				roomName := func() string { return "Spam Room" }() // Use closure to avoid name conflicts
 
 				start := time.Now()
-				_, err := client.CreateRoom(roomName, "", "test.matrix.org", true, "")
+				_, err := client.CreateRoom(roomName, "", "test.example.invalid", true, "")
 				elapsed := time.Since(start)
 
 				if err != nil {
@@ -266,7 +266,7 @@ func TestClient_MixedOperationLoad(t *testing.T) {
 	config := TestRateLimitConfig()
 
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	const numWorkers = 15
 	const operationsPerWorker = 10
@@ -296,7 +296,7 @@ func TestClient_MixedOperationLoad(t *testing.T) {
 					// Room creation (less frequent)
 					atomic.AddInt64(&roomAttempts, 1)
 					start := time.Now()
-					_, err := client.CreateRoom("Mixed Load Room", "", "test.matrix.org", true, "")
+					_, err := client.CreateRoom("Mixed Load Room", "", "test.example.invalid", true, "")
 					elapsed := time.Since(start)
 
 					if err != nil && elapsed > 200*time.Millisecond {
@@ -307,8 +307,8 @@ func TestClient_MixedOperationLoad(t *testing.T) {
 					atomic.AddInt64(&messageAttempts, 1)
 					start := time.Now()
 					_, err := client.SendMessage(MessageRequest{
-						RoomID:      "!mixed-load:matrix.org",
-						GhostUserID: "@mixed-user:matrix.org",
+						RoomID:      "!mixed-load:example.invalid",
+						GhostUserID: "@mixed-user:example.invalid",
 						Message:     "Mixed load test message",
 					})
 					elapsed := time.Since(start)
@@ -451,7 +451,7 @@ func TestClient_RateLimitingEffectiveness_Integration(t *testing.T) {
 	// Use standard test config which provides fast but consistent throttling validation
 	config := TestRateLimitConfig()
 	logger := NewTestLogger(t)
-	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
 
 	// Calculate expected timing thresholds from actual config
 	var expectedThrottleDelay time.Duration
@@ -471,8 +471,8 @@ func TestClient_RateLimitingEffectiveness_Integration(t *testing.T) {
 
 	// Test rapid message sending (what was failing)
 	messageReq := MessageRequest{
-		RoomID:      "!integration-test:matrix.org",
-		GhostUserID: "@integration-test:matrix.org",
+		RoomID:      "!integration-test:example.invalid",
+		GhostUserID: "@integration-test:example.invalid",
 		Message:     "Integration test message",
 	}
 

--- a/server/matrix/ratelimit_load_test.go
+++ b/server/matrix/ratelimit_load_test.go
@@ -118,7 +118,7 @@ func TestClient_MessageSpamLoad(t *testing.T) {
 	// Launch spammer goroutines
 	for i := 0; i < numSpammers; i++ {
 		wg.Add(1)
-		go func(spammerID int) {
+		go func(_ int) {
 			defer wg.Done()
 			for j := 0; j < messagesPerSpammer && ctx.Err() == nil; j++ {
 				atomic.AddInt64(&totalAttempts, 1)
@@ -204,7 +204,7 @@ func TestClient_RoomCreationSpamLoad(t *testing.T) {
 	// Launch room creator goroutines
 	for i := 0; i < numCreators; i++ {
 		wg.Add(1)
-		go func(creatorID int) {
+		go func(_ int) {
 			defer wg.Done()
 			for j := 0; j < roomsPerCreator && ctx.Err() == nil; j++ {
 				atomic.AddInt64(&totalAttempts, 1)
@@ -287,7 +287,7 @@ func TestClient_MixedOperationLoad(t *testing.T) {
 	// Launch mixed operation workers
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
-		go func(workerID int) {
+		go func(_ int) {
 			defer wg.Done()
 
 			for j := 0; j < operationsPerWorker && ctx.Err() == nil; j++ {
@@ -388,7 +388,7 @@ func TestTokenBucket_StressTest(t *testing.T) {
 	// Launch stress test goroutines
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
-		go func(goroutineID int) {
+		go func(_ int) {
 			defer wg.Done()
 
 			for j := 0; j < operationsPerGoroutine; j++ {
@@ -403,9 +403,10 @@ func TestTokenBucket_StressTest(t *testing.T) {
 				err := tb.Wait(opCtx)
 				opCancel()
 
-				if err == nil {
+				switch err {
+				case nil:
 					atomic.AddInt64(&allowedOperations, 1)
-				} else if err == context.DeadlineExceeded {
+				case context.DeadlineExceeded:
 					atomic.AddInt64(&timeoutOperations, 1)
 				}
 

--- a/server/matrix/ratelimit_load_test.go
+++ b/server/matrix/ratelimit_load_test.go
@@ -87,8 +87,8 @@ func TestClient_MessageSpamLoad(t *testing.T) {
 		t.Skip("Skipping load test in short mode")
 	}
 
-	// Use standard test configuration for consistent behavior across all tests
-	config := TestRateLimitConfig()
+	// Use load test configuration optimized for measurable throttling
+	config := LoadTestRateLimitConfig()
 
 	logger := NewTestLogger(t)
 	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
@@ -180,8 +180,8 @@ func TestClient_RoomCreationSpamLoad(t *testing.T) {
 		t.Skip("Skipping load test in short mode")
 	}
 
-	// Use standard test configuration for consistent behavior across all tests
-	config := TestRateLimitConfig()
+	// Use load test configuration optimized for measurable throttling
+	config := LoadTestRateLimitConfig()
 
 	logger := NewTestLogger(t)
 	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)
@@ -262,8 +262,8 @@ func TestClient_MixedOperationLoad(t *testing.T) {
 		t.Skip("Skipping load test in short mode")
 	}
 
-	// Use standard test configuration for consistent behavior across all tests
-	config := TestRateLimitConfig()
+	// Use load test configuration optimized for measurable throttling
+	config := LoadTestRateLimitConfig()
 
 	logger := NewTestLogger(t)
 	client := NewClientWithLoggerAndRateLimit("http://localhost:1", "test_token", "test_remote", logger, config)

--- a/server/matrix/ratelimit_load_test.go
+++ b/server/matrix/ratelimit_load_test.go
@@ -1,0 +1,517 @@
+package matrix
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTokenBucket_HighTrafficLoad tests that TokenBucket can handle high traffic
+// and properly throttles requests under extreme load
+func TestTokenBucket_HighTrafficLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping load test in short mode")
+	}
+
+	config := TokenBucketConfig{
+		Rate:      0, // Disable token bucket
+		BurstSize: 0,
+		Interval:  10 * time.Millisecond, // 10ms interval = max 100 requests/second
+	}
+
+	tb := NewTokenBucket(config)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const numWorkers = 50
+	const requestsPerWorker = 20
+	const expectedMaxThroughput = 100 // requests per second
+
+	var (
+		totalRequests   int64
+		successRequests int64
+		wg              sync.WaitGroup
+	)
+
+	startTime := time.Now()
+
+	// Launch workers that hammer the rate limiter
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < requestsPerWorker; j++ {
+				atomic.AddInt64(&totalRequests, 1)
+
+				// Try to get permission
+				if err := tb.Wait(ctx); err == nil {
+					atomic.AddInt64(&successRequests, 1)
+				} else if err == context.DeadlineExceeded {
+					// Expected when load exceeds capacity
+					break
+				} else {
+					t.Errorf("Worker %d: Unexpected error: %v", workerID, err)
+					break
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(startTime)
+
+	totalReqs := atomic.LoadInt64(&totalRequests)
+	successReqs := atomic.LoadInt64(&successRequests)
+	actualThroughput := float64(successReqs) / elapsed.Seconds()
+
+	t.Logf("Load test results:")
+	t.Logf("  Total requests attempted: %d", totalReqs)
+	t.Logf("  Successful requests: %d", successReqs)
+	t.Logf("  Elapsed time: %v", elapsed)
+	t.Logf("  Actual throughput: %.1f requests/second", actualThroughput)
+	t.Logf("  Expected max throughput: %d requests/second", expectedMaxThroughput)
+
+	// Verify that rate limiting worked
+	assert.Greater(t, totalReqs, successReqs, "Should have throttled some requests under high load")
+	assert.LessOrEqual(t, actualThroughput, float64(expectedMaxThroughput)*1.1, "Should not exceed expected throughput by more than 10%%")
+	assert.GreaterOrEqual(t, actualThroughput, float64(expectedMaxThroughput)*0.8, "Should achieve at least 80%% of expected throughput")
+}
+
+// TestClient_MessageSpamLoad tests that message rate limiting prevents overwhelming Matrix server
+func TestClient_MessageSpamLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping load test in short mode")
+	}
+
+	// Use standard test configuration for consistent behavior across all tests
+	config := TestRateLimitConfig()
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	req := MessageRequest{
+		RoomID:      "!spam-test:matrix.org",
+		GhostUserID: "@spammer:matrix.org",
+		Message:     "Spam message content",
+	}
+
+	const numSpammers = 20
+	const messagesPerSpammer = 10
+	const testDuration = 3 * time.Second
+	const expectedMaxRate = 5.0 // messages per second
+
+	var (
+		totalAttempts int64
+		rateLimited   int64
+		networkErrors int64
+		wg            sync.WaitGroup
+	)
+
+	startTime := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	// Launch spammer goroutines
+	for i := 0; i < numSpammers; i++ {
+		wg.Add(1)
+		go func(spammerID int) {
+			defer wg.Done()
+			for j := 0; j < messagesPerSpammer && ctx.Err() == nil; j++ {
+				atomic.AddInt64(&totalAttempts, 1)
+
+				start := time.Now()
+				_, err := client.SendMessage(req)
+				elapsed := time.Since(start)
+
+				if err != nil {
+					if elapsed > 100*time.Millisecond {
+						// Likely rate limited (took significant time)
+						atomic.AddInt64(&rateLimited, 1)
+					} else {
+						// Quick failure likely network error
+						atomic.AddInt64(&networkErrors, 1)
+					}
+				}
+
+				// Small delay to prevent busy spinning
+				time.Sleep(time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(startTime)
+
+	attempts := atomic.LoadInt64(&totalAttempts)
+	throttled := atomic.LoadInt64(&rateLimited)
+	netErrs := atomic.LoadInt64(&networkErrors)
+
+	// Calculate effective rate if no rate limiting occurred
+	potentialRate := float64(attempts) / elapsed.Seconds()
+	throttlePercentage := float64(throttled) / float64(attempts) * 100
+
+	t.Logf("Message spam load test results:")
+	t.Logf("  Total message attempts: %d", attempts)
+	t.Logf("  Rate limited: %d (%.1f%%)", throttled, throttlePercentage)
+	t.Logf("  Network errors: %d", netErrs)
+	t.Logf("  Test duration: %v", elapsed)
+	t.Logf("  Potential rate without limiting: %.1f messages/second", potentialRate)
+	t.Logf("  Expected max rate: %.1f messages/second", expectedMaxRate)
+
+	// Verify that rate limiting is working effectively
+	assert.Greater(t, attempts, int64(0), "Should have attempted some messages")
+	assert.Greater(t, throttled, int64(0), "Should have rate limited some messages under high load")
+	assert.Greater(t, throttlePercentage, 50.0, "Should have throttled significant percentage of spam attempts")
+
+	// Verify we're not allowing way more than the configured rate
+	if potentialRate > expectedMaxRate*2 {
+		t.Errorf("Rate limiting may be ineffective: potential rate %.1f exceeds expected max rate %.1f by more than 2x",
+			potentialRate, expectedMaxRate)
+	}
+}
+
+// TestClient_RoomCreationSpamLoad tests room creation rate limiting under heavy load
+func TestClient_RoomCreationSpamLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping load test in short mode")
+	}
+
+	// Use standard test configuration for consistent behavior across all tests
+	config := TestRateLimitConfig()
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	const numCreators = 10
+	const roomsPerCreator = 5
+	const testDuration = 4 * time.Second
+
+	var (
+		totalAttempts int64
+		rateLimited   int64
+		networkErrors int64
+		wg            sync.WaitGroup
+	)
+
+	startTime := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	// Launch room creator goroutines
+	for i := 0; i < numCreators; i++ {
+		wg.Add(1)
+		go func(creatorID int) {
+			defer wg.Done()
+			for j := 0; j < roomsPerCreator && ctx.Err() == nil; j++ {
+				atomic.AddInt64(&totalAttempts, 1)
+
+				roomName := func() string { return "Spam Room" }() // Use closure to avoid name conflicts
+
+				start := time.Now()
+				_, err := client.CreateRoom(roomName, "", "test.matrix.org", true, "")
+				elapsed := time.Since(start)
+
+				if err != nil {
+					if elapsed > 200*time.Millisecond {
+						// Likely rate limited
+						atomic.AddInt64(&rateLimited, 1)
+					} else {
+						// Quick failure likely network error
+						atomic.AddInt64(&networkErrors, 1)
+					}
+				}
+
+				// Small delay
+				time.Sleep(10 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(startTime)
+
+	attempts := atomic.LoadInt64(&totalAttempts)
+	throttled := atomic.LoadInt64(&rateLimited)
+	netErrs := atomic.LoadInt64(&networkErrors)
+
+	potentialRate := float64(attempts) / elapsed.Seconds()
+	throttlePercentage := float64(throttled) / float64(attempts) * 100
+	expectedMaxRate := 2.0 // 1 room per 500ms = 2 rooms per second
+
+	t.Logf("Room creation spam load test results:")
+	t.Logf("  Total room creation attempts: %d", attempts)
+	t.Logf("  Rate limited: %d (%.1f%%)", throttled, throttlePercentage)
+	t.Logf("  Network errors: %d", netErrs)
+	t.Logf("  Test duration: %v", elapsed)
+	t.Logf("  Potential rate without limiting: %.1f rooms/second", potentialRate)
+	t.Logf("  Expected max rate: %.1f rooms/second", expectedMaxRate)
+
+	// Verify room creation rate limiting is working
+	assert.Greater(t, attempts, int64(0), "Should have attempted some room creations")
+	assert.Greater(t, throttled, int64(0), "Should have rate limited some room creation attempts")
+	assert.Greater(t, throttlePercentage, 30.0, "Should have throttled significant percentage of room creation spam")
+}
+
+// TestClient_MixedOperationLoad tests rate limiting with mixed operations under load
+func TestClient_MixedOperationLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping load test in short mode")
+	}
+
+	// Use standard test configuration for consistent behavior across all tests
+	config := TestRateLimitConfig()
+
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	const numWorkers = 15
+	const operationsPerWorker = 10
+	const testDuration = 5 * time.Second
+
+	var (
+		messageAttempts  int64
+		messageThrottled int64
+		roomAttempts     int64
+		roomThrottled    int64
+		wg               sync.WaitGroup
+	)
+
+	startTime := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	// Launch mixed operation workers
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+
+			for j := 0; j < operationsPerWorker && ctx.Err() == nil; j++ {
+				// Alternate between messages and room creation
+				if j%3 == 0 {
+					// Room creation (less frequent)
+					atomic.AddInt64(&roomAttempts, 1)
+					start := time.Now()
+					_, err := client.CreateRoom("Mixed Load Room", "", "test.matrix.org", true, "")
+					elapsed := time.Since(start)
+
+					if err != nil && elapsed > 200*time.Millisecond {
+						atomic.AddInt64(&roomThrottled, 1)
+					}
+				} else {
+					// Message sending (more frequent)
+					atomic.AddInt64(&messageAttempts, 1)
+					start := time.Now()
+					_, err := client.SendMessage(MessageRequest{
+						RoomID:      "!mixed-load:matrix.org",
+						GhostUserID: "@mixed-user:matrix.org",
+						Message:     "Mixed load test message",
+					})
+					elapsed := time.Since(start)
+
+					if err != nil && elapsed > 100*time.Millisecond {
+						atomic.AddInt64(&messageThrottled, 1)
+					}
+				}
+
+				// Brief pause
+				time.Sleep(20 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(startTime)
+
+	msgAttempts := atomic.LoadInt64(&messageAttempts)
+	msgThrottled := atomic.LoadInt64(&messageThrottled)
+	rmAttempts := atomic.LoadInt64(&roomAttempts)
+	rmThrottled := atomic.LoadInt64(&roomThrottled)
+
+	msgThrottleRate := float64(msgThrottled) / float64(msgAttempts) * 100
+	roomThrottleRate := float64(rmThrottled) / float64(rmAttempts) * 100
+
+	t.Logf("Mixed operation load test results:")
+	t.Logf("  Test duration: %v", elapsed)
+	t.Logf("  Message attempts: %d, throttled: %d (%.1f%%)", msgAttempts, msgThrottled, msgThrottleRate)
+	t.Logf("  Room creation attempts: %d, throttled: %d (%.1f%%)", rmAttempts, rmThrottled, roomThrottleRate)
+
+	// Verify that rate limiting is working for mixed operations
+	assert.Greater(t, msgAttempts, int64(0), "Should have attempted messages")
+	assert.Greater(t, rmAttempts, int64(0), "Should have attempted room creations")
+
+	// Room creation should be more aggressively throttled due to stricter limits
+	if rmAttempts > 5 {
+		assert.Greater(t, roomThrottleRate, msgThrottleRate, "Room creation should be throttled more aggressively than messages")
+	}
+
+	// Both should show some throttling under mixed high load
+	if msgAttempts > 20 {
+		assert.Greater(t, msgThrottleRate, 10.0, "Should throttle some messages under high mixed load")
+	}
+}
+
+// TestTokenBucket_StressTest tests TokenBucket under extreme concurrent stress
+func TestTokenBucket_StressTest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping stress test in short mode")
+	}
+
+	config := TokenBucketConfig{
+		Rate:      100.0, // 100 operations per second
+		BurstSize: 50,    // Allow burst of 50
+		Interval:  0,
+	}
+
+	tb := NewTokenBucket(config)
+
+	const numGoroutines = 100
+	const operationsPerGoroutine = 100
+	const testDuration = 3 * time.Second
+
+	var (
+		totalOperations   int64
+		allowedOperations int64
+		timeoutOperations int64
+		wg                sync.WaitGroup
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testDuration)
+	defer cancel()
+
+	startTime := time.Now()
+
+	// Launch stress test goroutines
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			for j := 0; j < operationsPerGoroutine; j++ {
+				if ctx.Err() != nil {
+					break
+				}
+
+				atomic.AddInt64(&totalOperations, 1)
+
+				// Use a short timeout to avoid blocking too long
+				opCtx, opCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+				err := tb.Wait(opCtx)
+				opCancel()
+
+				if err == nil {
+					atomic.AddInt64(&allowedOperations, 1)
+				} else if err == context.DeadlineExceeded {
+					atomic.AddInt64(&timeoutOperations, 1)
+				}
+
+				// Brief pause to avoid busy spinning
+				time.Sleep(time.Microsecond * 100)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(startTime)
+
+	total := atomic.LoadInt64(&totalOperations)
+	allowed := atomic.LoadInt64(&allowedOperations)
+	timeouts := atomic.LoadInt64(&timeoutOperations)
+
+	allowedRate := float64(allowed) / elapsed.Seconds()
+	timeoutPercentage := float64(timeouts) / float64(total) * 100
+
+	t.Logf("TokenBucket stress test results:")
+	t.Logf("  Test duration: %v", elapsed)
+	t.Logf("  Total operations attempted: %d", total)
+	t.Logf("  Operations allowed: %d", allowed)
+	t.Logf("  Operations timed out: %d (%.1f%%)", timeouts, timeoutPercentage)
+	t.Logf("  Effective allowed rate: %.1f operations/second", allowedRate)
+	t.Logf("  Expected max rate: 100 operations/second")
+
+	// Verify stress test results
+	assert.Greater(t, total, int64(1000), "Should have attempted many operations")
+	assert.Greater(t, allowed, int64(100), "Should have allowed reasonable number of operations")
+	assert.Greater(t, timeoutPercentage, 50.0, "Should have timed out majority of operations under extreme stress")
+	assert.LessOrEqual(t, allowedRate, 120.0, "Should not exceed configured rate by more than 20%% even under stress")
+	assert.GreaterOrEqual(t, allowedRate, 80.0, "Should achieve at least 80%% of configured rate under stress")
+}
+
+// TestClient_RateLimitingEffectiveness_Integration tests that rate limiting
+// actually prevents the issues it's designed to solve
+func TestClient_RateLimitingEffectiveness_Integration(t *testing.T) {
+	// This test verifies that our rate limiting would prevent the original
+	// 429 M_LIMIT_EXCEEDED errors we were seeing in CI
+
+	// Use standard test config which provides fast but consistent throttling validation
+	config := TestRateLimitConfig()
+	logger := NewTestLogger(t)
+	client := NewClientWithLoggerAndRateLimit("https://test.matrix.org", "test_token", "test_remote", logger, config)
+
+	// Calculate expected timing thresholds from actual config
+	var expectedThrottleDelay time.Duration
+	if config.Messages.Interval > 0 {
+		// Interval-based rate limiting
+		expectedThrottleDelay = config.Messages.Interval
+	} else if config.Messages.Rate > 0 {
+		// Token bucket rate limiting: 1/rate = seconds per token
+		expectedThrottleDelay = time.Duration(float64(time.Second) / config.Messages.Rate)
+	}
+
+	// Use 80% of expected delay as threshold to account for timing variations
+	throttleThreshold := time.Duration(float64(expectedThrottleDelay) * 0.8)
+
+	// Simulate the rapid operations that were causing failures
+	const rapidOperations = 20
+
+	// Test rapid message sending (what was failing)
+	messageReq := MessageRequest{
+		RoomID:      "!integration-test:matrix.org",
+		GhostUserID: "@integration-test:matrix.org",
+		Message:     "Integration test message",
+	}
+
+	var messageDurations []time.Duration
+	for i := 0; i < rapidOperations; i++ {
+		start := time.Now()
+		_, err := client.SendMessage(messageReq)
+		duration := time.Since(start)
+		messageDurations = append(messageDurations, duration)
+
+		// We expect network errors, but importantly, no rate limiting should cause long delays
+		// beyond the first few burst messages
+		assert.Error(t, err, "Expected network error")
+	}
+
+	// Analyze the timing pattern
+	immediateCount := 0
+	throttledCount := 0
+
+	for i, duration := range messageDurations {
+		if duration < 50*time.Millisecond {
+			immediateCount++
+		} else if duration > throttleThreshold {
+			throttledCount++
+		}
+
+		t.Logf("Message %d: %v", i+1, duration)
+	}
+
+	t.Logf("Integration test results:")
+	t.Logf("  Rate limit config: %v messages/sec, burst: %d", config.Messages.Rate, config.Messages.BurstSize)
+	t.Logf("  Expected throttle delay: %v, threshold: %v", expectedThrottleDelay, throttleThreshold)
+	t.Logf("  Immediate messages (burst): %d", immediateCount)
+	t.Logf("  Throttled messages: %d", throttledCount)
+
+	// Verify that rate limiting is working as designed
+	assert.Greater(t, immediateCount, 0, "Should allow some immediate messages (burst)")
+	assert.GreaterOrEqual(t, throttledCount, rapidOperations/2, "Should throttle at least half of rapid messages")
+
+	// Most importantly: if we were actually hitting a Matrix server, these delays
+	// should prevent 429 M_LIMIT_EXCEEDED errors because we're self-limiting
+	// to be more restrictive than typical Matrix server limits
+}

--- a/server/matrix/ratelimit_test.go
+++ b/server/matrix/ratelimit_test.go
@@ -262,22 +262,22 @@ func TestDefaultRateLimitConfig(t *testing.T) {
 }
 
 func TestTestRateLimitConfig(t *testing.T) {
-	config := TestRateLimitConfig()
+	config := UnitTestRateLimitConfig()
 
-	assert.True(t, config.Enabled, "Test config should be enabled")
-	// Test config now uses Conservative mode (matches Synapse defaults) to avoid 429 errors
-	assert.Equal(t, 0.05, config.RoomCreation.Rate, "Test config should have 0.05 rooms per second")
-	assert.Equal(t, 2, config.RoomCreation.BurstSize, "Test config should have burst of 2 rooms")
+	assert.True(t, config.Enabled, "Unit test config should be enabled")
+	// Unit test config uses shared constants - tests automatically stay in sync when constants change
+	assert.Equal(t, UnitTestRoomCreationRate, config.RoomCreation.Rate, "Unit test config should use UnitTestRoomCreationRate constant")
+	assert.Equal(t, UnitTestRoomCreationBurstSize, config.RoomCreation.BurstSize, "Unit test config should use UnitTestRoomCreationBurstSize constant")
 	assert.Equal(t, time.Duration(0), config.RoomCreation.Interval, "Test config should use token bucket for room creation")
-	assert.Equal(t, 0.2, config.Messages.Rate, "Test config should allow 0.2 messages per second")
-	assert.Equal(t, 10, config.Messages.BurstSize, "Test config should have burst of 10 messages")
-	assert.Equal(t, 0.3, config.Invites.Rate, "Test config should allow 0.3 invites per second")
-	assert.Equal(t, 10, config.Invites.BurstSize, "Test config should have burst of 10 invites")
-	assert.Equal(t, 0.17, config.Registration.Rate, "Test config should allow 0.17 registrations per second")
-	assert.Equal(t, 3, config.Registration.BurstSize, "Test config should have burst of 3 registrations")
+	assert.Equal(t, UnitTestMessageRate, config.Messages.Rate, "Unit test config should use UnitTestMessageRate constant")
+	assert.Equal(t, UnitTestMessageBurstSize, config.Messages.BurstSize, "Unit test config should use UnitTestMessageBurstSize constant")
+	assert.Equal(t, UnitTestInviteRate, config.Invites.Rate, "Unit test config should use UnitTestInviteRate constant")
+	assert.Equal(t, UnitTestInviteBurstSize, config.Invites.BurstSize, "Unit test config should use UnitTestInviteBurstSize constant")
+	assert.Equal(t, UnitTestRegistrationRate, config.Registration.Rate, "Unit test config should use UnitTestRegistrationRate constant")
+	assert.Equal(t, UnitTestRegistrationBurstSize, config.Registration.BurstSize, "Unit test config should use UnitTestRegistrationBurstSize constant")
 	assert.Equal(t, time.Duration(0), config.Registration.Interval, "Test config should use token bucket for registration")
-	assert.Equal(t, 0.2, config.Joins.Rate, "Test config should allow 0.2 joins per second")
-	assert.Equal(t, 5, config.Joins.BurstSize, "Test config should have burst of 5 joins")
+	assert.Equal(t, UnitTestJoinRate, config.Joins.Rate, "Unit test config should use UnitTestJoinRate constant")
+	assert.Equal(t, UnitTestJoinBurstSize, config.Joins.BurstSize, "Unit test config should use UnitTestJoinBurstSize constant")
 }
 
 func TestGetRateLimitConfigByMode(t *testing.T) {

--- a/server/matrix/ratelimit_test.go
+++ b/server/matrix/ratelimit_test.go
@@ -265,19 +265,19 @@ func TestTestRateLimitConfig(t *testing.T) {
 	config := TestRateLimitConfig()
 
 	assert.True(t, config.Enabled, "Test config should be enabled")
-	// Test config now uses Relaxed mode (5x faster than Synapse defaults) for efficient testing
-	assert.Equal(t, 0.25, config.RoomCreation.Rate, "Test config should have 0.25 rooms per second")
-	assert.Equal(t, 3, config.RoomCreation.BurstSize, "Test config should have burst of 3 rooms")
+	// Test config now uses Conservative mode (matches Synapse defaults) to avoid 429 errors
+	assert.Equal(t, 0.05, config.RoomCreation.Rate, "Test config should have 0.05 rooms per second")
+	assert.Equal(t, 2, config.RoomCreation.BurstSize, "Test config should have burst of 2 rooms")
 	assert.Equal(t, time.Duration(0), config.RoomCreation.Interval, "Test config should use token bucket for room creation")
-	assert.Equal(t, 1.0, config.Messages.Rate, "Test config should allow 1 messages per second")
-	assert.Equal(t, 15, config.Messages.BurstSize, "Test config should have burst of 15 messages")
-	assert.Equal(t, 1.5, config.Invites.Rate, "Test config should allow 1.5 invites per second")
-	assert.Equal(t, 15, config.Invites.BurstSize, "Test config should have burst of 15 invites")
-	assert.Equal(t, 0.85, config.Registration.Rate, "Test config should allow 0.85 registrations per second")
-	assert.Equal(t, 5, config.Registration.BurstSize, "Test config should have burst of 5 registrations")
+	assert.Equal(t, 0.2, config.Messages.Rate, "Test config should allow 0.2 messages per second")
+	assert.Equal(t, 10, config.Messages.BurstSize, "Test config should have burst of 10 messages")
+	assert.Equal(t, 0.3, config.Invites.Rate, "Test config should allow 0.3 invites per second")
+	assert.Equal(t, 10, config.Invites.BurstSize, "Test config should have burst of 10 invites")
+	assert.Equal(t, 0.17, config.Registration.Rate, "Test config should allow 0.17 registrations per second")
+	assert.Equal(t, 3, config.Registration.BurstSize, "Test config should have burst of 3 registrations")
 	assert.Equal(t, time.Duration(0), config.Registration.Interval, "Test config should use token bucket for registration")
-	assert.Equal(t, 1.0, config.Joins.Rate, "Test config should allow 1 joins per second")
-	assert.Equal(t, 8, config.Joins.BurstSize, "Test config should have burst of 8 joins")
+	assert.Equal(t, 0.2, config.Joins.Rate, "Test config should allow 0.2 joins per second")
+	assert.Equal(t, 5, config.Joins.BurstSize, "Test config should have burst of 5 joins")
 }
 
 func TestGetRateLimitConfigByMode(t *testing.T) {

--- a/server/matrix/ratelimit_test.go
+++ b/server/matrix/ratelimit_test.go
@@ -1,0 +1,71 @@
+package matrix
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestIsRateLimitError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "Matrix 429 error with M_LIMIT_EXCEEDED",
+			err: &Error{
+				StatusCode: 429,
+				ErrCode:    "M_LIMIT_EXCEEDED",
+				ErrMsg:     "Too Many Requests",
+			},
+			expected: true,
+		},
+		{
+			name: "Matrix error with M_LIMIT_EXCEEDED code only",
+			err: &Error{
+				StatusCode: 500,
+				ErrCode:    "M_LIMIT_EXCEEDED",
+				ErrMsg:     "Rate limit exceeded",
+			},
+			expected: true,
+		},
+		{
+			name: "Matrix 429 error without M_LIMIT_EXCEEDED",
+			err: &Error{
+				StatusCode: 429,
+				ErrCode:    "UNKNOWN",
+				ErrMsg:     "Too Many Requests",
+			},
+			expected: true,
+		},
+		{
+			name: "Non-rate limit Matrix error",
+			err: &Error{
+				StatusCode: 400,
+				ErrCode:    "M_INVALID_PARAM",
+				ErrMsg:     "Bad request",
+			},
+			expected: false,
+		},
+		{
+			name:     "Non-Matrix error",
+			err:      errors.New("network error"),
+			expected: false,
+		},
+		{
+			name:     "Nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRateLimitError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsRateLimitError() = %v, expected %v for error: %v", result, tt.expected, tt.err)
+			}
+		})
+	}
+}

--- a/server/matrix/ratelimit_test.go
+++ b/server/matrix/ratelimit_test.go
@@ -1,0 +1,339 @@
+package matrix
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenBucket_Allow_IntervalBased(t *testing.T) {
+	// Test interval-based rate limiting (like room creation: 2 second intervals)
+	config := TokenBucketConfig{
+		Rate:      0, // Disable token bucket
+		BurstSize: 0,
+		Interval:  100 * time.Millisecond, // 100ms minimum interval
+	}
+
+	tb := NewTokenBucket(config)
+
+	// First call should succeed
+	assert.True(t, tb.Allow(), "First call should be allowed")
+
+	// Immediate second call should fail (within interval)
+	assert.False(t, tb.Allow(), "Second immediate call should be blocked")
+
+	// Wait for interval to pass
+	time.Sleep(120 * time.Millisecond)
+
+	// Third call should succeed after interval
+	assert.True(t, tb.Allow(), "Call after interval should be allowed")
+}
+
+func TestTokenBucket_Allow_TokenBased(t *testing.T) {
+	// Test token bucket rate limiting (like messages: 1 per second, burst 10)
+	config := TokenBucketConfig{
+		Rate:      1.0, // 1 token per second
+		BurstSize: 3,   // Allow burst of 3
+		Interval:  0,   // No interval-based limiting
+	}
+
+	tb := NewTokenBucket(config)
+
+	// Should allow burst size number of calls immediately
+	for i := 0; i < 3; i++ {
+		assert.True(t, tb.Allow(), "Burst call %d should be allowed", i+1)
+	}
+
+	// Fourth call should fail (burst exhausted)
+	assert.False(t, tb.Allow(), "Call after burst should be blocked")
+
+	// Wait for one token to regenerate
+	time.Sleep(1200 * time.Millisecond)
+
+	// Should allow one more call
+	assert.True(t, tb.Allow(), "Call after token regeneration should be allowed")
+}
+
+func TestTokenBucket_Wait_IntervalBased(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      0,
+		BurstSize: 0,
+		Interval:  50 * time.Millisecond,
+	}
+
+	tb := NewTokenBucket(config)
+	ctx := context.Background()
+
+	// First call should succeed immediately
+	start := time.Now()
+	err := tb.Wait(ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 10*time.Millisecond, "First call should be immediate")
+
+	// Second call should wait for interval
+	start = time.Now()
+	err = tb.Wait(ctx)
+	elapsed = time.Since(start)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, 45*time.Millisecond, "Second call should wait ~50ms")
+	assert.Less(t, elapsed, 100*time.Millisecond, "Wait should not be excessive")
+}
+
+func TestTokenBucket_Wait_TokenBased(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      10.0, // 10 tokens per second = 100ms per token
+		BurstSize: 2,    // Allow burst of 2
+		Interval:  0,
+	}
+
+	tb := NewTokenBucket(config)
+	ctx := context.Background()
+
+	// First two calls should succeed immediately (burst)
+	for i := 0; i < 2; i++ {
+		start := time.Now()
+		err := tb.Wait(ctx)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		assert.Less(t, elapsed, 10*time.Millisecond, "Burst call %d should be immediate", i+1)
+	}
+
+	// Third call should wait for token regeneration
+	start := time.Now()
+	err := tb.Wait(ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "Third call should wait ~100ms")
+	assert.Less(t, elapsed, 150*time.Millisecond, "Wait should not be excessive")
+}
+
+func TestTokenBucket_Wait_Timeout(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      0,
+		BurstSize: 0,
+		Interval:  1 * time.Second, // Long interval
+	}
+
+	tb := NewTokenBucket(config)
+
+	// First call to consume the initial allowance
+	require.True(t, tb.Allow())
+
+	// Second call should timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := tb.Wait(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.GreaterOrEqual(t, elapsed, 90*time.Millisecond, "Should wait for timeout")
+	assert.Less(t, elapsed, 150*time.Millisecond, "Should not wait too long")
+}
+
+func TestTokenBucket_ConcurrentAccess(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      0,
+		BurstSize: 0,
+		Interval:  20 * time.Millisecond,
+	}
+
+	tb := NewTokenBucket(config)
+	ctx := context.Background()
+
+	const numGoroutines = 10
+	const callsPerGoroutine = 5
+
+	var wg sync.WaitGroup
+	results := make(chan time.Duration, numGoroutines*callsPerGoroutine)
+
+	// Launch multiple goroutines that all try to call Wait()
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				start := time.Now()
+				err := tb.Wait(ctx)
+				elapsed := time.Since(start)
+				require.NoError(t, err)
+				results <- elapsed
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Collect all results
+	var durations []time.Duration
+	for duration := range results {
+		durations = append(durations, duration)
+	}
+
+	// Should have all calls completed
+	assert.Len(t, durations, numGoroutines*callsPerGoroutine)
+
+	// First call should be immediate, subsequent calls should have increasing delays
+	// due to the interval-based rate limiting under concurrent access
+	immediateCount := 0
+	delayedCount := 0
+
+	for _, duration := range durations {
+		if duration < 10*time.Millisecond {
+			immediateCount++
+		} else {
+			delayedCount++
+		}
+	}
+
+	// Only one call should be immediate (the first one)
+	assert.Equal(t, 1, immediateCount, "Only first call should be immediate")
+	assert.Equal(t, numGoroutines*callsPerGoroutine-1, delayedCount, "All other calls should be delayed")
+}
+
+func TestTokenBucket_getWaitTime_IntervalBased(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      0,
+		BurstSize: 0,
+		Interval:  100 * time.Millisecond,
+	}
+
+	tb := NewTokenBucket(config)
+
+	// Before any operations, wait time should be 0
+	waitTime := tb.getWaitTime()
+	assert.Equal(t, time.Duration(0), waitTime, "Initial wait time should be 0")
+
+	// After first operation, immediate second operation should need to wait
+	require.True(t, tb.Allow())
+	waitTime = tb.getWaitTime()
+	assert.GreaterOrEqual(t, waitTime, 90*time.Millisecond, "Should need to wait ~100ms")
+	assert.LessOrEqual(t, waitTime, 100*time.Millisecond, "Wait time should not exceed interval")
+
+	// After waiting, should not need to wait again
+	time.Sleep(waitTime + 10*time.Millisecond)
+	waitTime = tb.getWaitTime()
+	assert.Equal(t, time.Duration(0), waitTime, "After waiting, should not need to wait again")
+}
+
+func TestTokenBucket_getWaitTime_TokenBased(t *testing.T) {
+	config := TokenBucketConfig{
+		Rate:      10.0, // 10 tokens per second = 100ms per token
+		BurstSize: 2,
+		Interval:  0,
+	}
+
+	tb := NewTokenBucket(config)
+
+	// With burst available, wait time should be 0
+	waitTime := tb.getWaitTime()
+	assert.Equal(t, time.Duration(0), waitTime, "With tokens available, wait time should be 0")
+
+	// Exhaust burst
+	require.True(t, tb.Allow())
+	require.True(t, tb.Allow())
+
+	// Now should need to wait for token regeneration
+	waitTime = tb.getWaitTime()
+	assert.GreaterOrEqual(t, waitTime, 90*time.Millisecond, "Should need to wait ~100ms for token")
+	assert.LessOrEqual(t, waitTime, 110*time.Millisecond, "Wait time should be reasonable")
+}
+
+func TestDefaultRateLimitConfig(t *testing.T) {
+	config := DefaultRateLimitConfig()
+
+	assert.True(t, config.Enabled, "Default config should be enabled")
+	assert.Greater(t, config.RoomCreation.Rate, 0.0, "Room creation should have positive rate")
+	assert.Greater(t, config.Messages.Rate, 0.0, "Messages should have positive rate")
+	assert.Greater(t, config.Messages.BurstSize, 0, "Messages should have burst size")
+	assert.Greater(t, config.Invites.Rate, 0.0, "Invites should have positive rate")
+}
+
+func TestTestRateLimitConfig(t *testing.T) {
+	config := TestRateLimitConfig()
+
+	assert.True(t, config.Enabled, "Test config should be enabled")
+	// Test config uses fast rates (10x faster than production) for efficient testing
+	assert.Equal(t, 0.5, config.RoomCreation.Rate, "Test config should have 0.5 rooms per second")
+	assert.Equal(t, 2, config.RoomCreation.BurstSize, "Test config should have burst of 2 rooms")
+	assert.Equal(t, time.Duration(0), config.RoomCreation.Interval, "Test config should use token bucket for room creation")
+	assert.Equal(t, 2.0, config.Messages.Rate, "Test config should allow 2 messages per second")
+	assert.Equal(t, 10, config.Messages.BurstSize, "Test config should have burst of 10 messages")
+	assert.Equal(t, 3.0, config.Invites.Rate, "Test config should allow 3 invites per second")
+	assert.Equal(t, 10, config.Invites.BurstSize, "Test config should have burst of 10 invites")
+	assert.Equal(t, 1.7, config.Registration.Rate, "Test config should allow 1.7 registrations per second")
+	assert.Equal(t, 3, config.Registration.BurstSize, "Test config should have burst of 3 registrations")
+	assert.Equal(t, time.Duration(0), config.Registration.Interval, "Test config should use token bucket for registration")
+	assert.Equal(t, 2.0, config.Joins.Rate, "Test config should allow 2 joins per second")
+	assert.Equal(t, 5, config.Joins.BurstSize, "Test config should have burst of 5 joins")
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	// This test already exists in ratelimit_test.go, but let's make sure it's comprehensive
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "Matrix 429 error with M_LIMIT_EXCEEDED",
+			err: &Error{
+				StatusCode: 429,
+				ErrCode:    "M_LIMIT_EXCEEDED",
+				ErrMsg:     "Too Many Requests",
+			},
+			expected: true,
+		},
+		{
+			name: "Matrix error with M_LIMIT_EXCEEDED code only",
+			err: &Error{
+				StatusCode: 500,
+				ErrCode:    "M_LIMIT_EXCEEDED",
+				ErrMsg:     "Rate limit exceeded",
+			},
+			expected: true,
+		},
+		{
+			name: "Matrix 429 error without M_LIMIT_EXCEEDED",
+			err: &Error{
+				StatusCode: 429,
+				ErrCode:    "UNKNOWN",
+				ErrMsg:     "Too Many Requests",
+			},
+			expected: true,
+		},
+		{
+			name: "Non-rate limit Matrix error",
+			err: &Error{
+				StatusCode: 400,
+				ErrCode:    "M_INVALID_PARAM",
+				ErrMsg:     "Bad request",
+			},
+			expected: false,
+		},
+		{
+			name:     "Wrapped rate limit error",
+			err:      &Error{StatusCode: 429, ErrCode: "M_LIMIT_EXCEEDED"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRateLimitError(tt.err)
+			assert.Equal(t, tt.expected, result, "IsRateLimitError() mismatch for error: %v", tt.err)
+		})
+	}
+}

--- a/server/matrix/test/client_test.go
+++ b/server/matrix/test/client_test.go
@@ -445,17 +445,17 @@ func BenchmarkMatrixClientOperations(b *testing.B) {
 // TestMatrixClientErrorHandling tests error handling and edge cases
 func (suite *MatrixClientTestSuite) TestMatrixClientErrorHandling() {
 	suite.Run("EmptyTokenClient", func() {
-		// Test client with empty token
+		// Test client with empty token (use fake URL to avoid hitting real server)
 		emptyTokenClient := matrix.NewClientWithLoggerAndRateLimit(
-			suite.matrixContainer.ServerURL,
-			"", // Empty token
+			"https://fake-matrix-server.invalid", // Fake URL - we're only testing empty token validation
+			"",                                   // Empty token
 			"test-remote-id",
 			matrix.NewTestLogger(suite.T()),
 			matrix.TestRateLimitConfig(),
 		)
 
-		// Should fail operations that require authentication
-		_, err := emptyTokenClient.CreateRoom("Test", "Test", suite.matrixContainer.ServerDomain, false, "test")
+		// Should fail operations that require authentication (use TestConnection instead of CreateRoom to avoid rate limits)
+		err := emptyTokenClient.TestConnection()
 		assert.Error(suite.T(), err, "Should fail with empty token")
 		assert.Contains(suite.T(), err.Error(), "not configured", "Error should mention configuration issue")
 	})

--- a/server/matrix/test/client_test.go
+++ b/server/matrix/test/client_test.go
@@ -446,11 +446,12 @@ func BenchmarkMatrixClientOperations(b *testing.B) {
 func (suite *MatrixClientTestSuite) TestMatrixClientErrorHandling() {
 	suite.Run("EmptyTokenClient", func() {
 		// Test client with empty token
-		emptyTokenClient := matrix.NewClientWithLogger(
+		emptyTokenClient := matrix.NewClientWithLoggerAndRateLimit(
 			suite.matrixContainer.ServerURL,
 			"", // Empty token
 			"test-remote-id",
 			matrix.NewTestLogger(suite.T()),
+			matrix.TestRateLimitConfig(),
 		)
 
 		// Should fail operations that require authentication
@@ -461,11 +462,12 @@ func (suite *MatrixClientTestSuite) TestMatrixClientErrorHandling() {
 
 	suite.Run("InvalidServerURL", func() {
 		// Test client with invalid server URL
-		invalidURLClient := matrix.NewClientWithLogger(
+		invalidURLClient := matrix.NewClientWithLoggerAndRateLimit(
 			"http://nonexistent.invalid:1234",
 			suite.matrixContainer.ASToken,
 			"test-remote-id",
 			matrix.NewTestLogger(suite.T()),
+			matrix.TestRateLimitConfig(),
 		)
 
 		err := invalidURLClient.TestConnection()
@@ -563,11 +565,12 @@ func (suite *MatrixClientTestSuite) TestMatrixClientErrorHandling() {
 
 	suite.Run("NetworkErrorHandling", func() {
 		// Test with client pointing to a port that definitely doesn't exist
-		networkFailClient := matrix.NewClientWithLogger(
+		networkFailClient := matrix.NewClientWithLoggerAndRateLimit(
 			"http://localhost:99999", // Port that should be unused
 			suite.matrixContainer.ASToken,
 			"test-remote-id",
 			matrix.NewTestLogger(suite.T()),
+			matrix.TestRateLimitConfig(),
 		)
 
 		// All operations should fail with network errors
@@ -1150,11 +1153,12 @@ func TestURLEscapingBehavior(t *testing.T) {
 
 func TestMXCURIValidationErrorReporting(t *testing.T) {
 	// Test improved error reporting for malformed MXC URIs
-	client := matrix.NewClientWithLogger(
+	client := matrix.NewClientWithLoggerAndRateLimit(
 		"https://matrix.example.com",
 		"test-token",
 		"test-remote-id",
 		matrix.NewTestLogger(t),
+		matrix.TestRateLimitConfig(),
 	)
 
 	testCases := []struct {
@@ -1194,11 +1198,12 @@ func TestMXCURIValidationErrorReporting(t *testing.T) {
 
 func TestMXCURIValidationErrorReportingWithBetterErrorMessages(t *testing.T) {
 	// Test that we get better error messages that help with debugging
-	client := matrix.NewClientWithLogger(
+	client := matrix.NewClientWithLoggerAndRateLimit(
 		"https://matrix.example.com",
 		"test-token",
 		"test-remote-id",
 		matrix.NewTestLogger(t),
+		matrix.TestRateLimitConfig(),
 	)
 
 	// Test path traversal error gets caught early with descriptive message

--- a/server/matrix/test/client_test.go
+++ b/server/matrix/test/client_test.go
@@ -41,9 +41,8 @@ func (suite *MatrixClientTestSuite) TearDownTest() {
 	}
 }
 
-// TestMatrixClientOperations tests core Matrix client operations that affect change
-// and then query the server to verify the changes were applied correctly.
-func (suite *MatrixClientTestSuite) TestMatrixClientOperations() {
+// TestMatrixClientBasicOperations tests basic Matrix client connectivity and permissions
+func (suite *MatrixClientTestSuite) TestMatrixClientBasicOperations() {
 	// Test server connectivity first
 	suite.Run("TestConnection", func() {
 		err := suite.client.TestConnection()
@@ -83,11 +82,11 @@ func (suite *MatrixClientTestSuite) TestMatrixClientOperations() {
 	suite.Run("MediaOperations", func() {
 		suite.testMediaOperations()
 	})
+}
 
-	// Run advanced room operation tests
-	suite.Run("AdvancedRoomOperations", func() {
-		suite.testAdvancedRoomOperations()
-	})
+// TestMatrixClientAdvancedRoomOperations tests advanced room operations with fresh container
+func (suite *MatrixClientTestSuite) TestMatrixClientAdvancedRoomOperations() {
+	suite.testAdvancedRoomOperations()
 }
 
 // testRoomOperations tests room creation, joining, and management operations

--- a/server/matrix/test/client_test.go
+++ b/server/matrix/test/client_test.go
@@ -20,20 +20,11 @@ type MatrixClientTestSuite struct {
 	client          *matrix.Client
 }
 
-// SetupSuite starts the Matrix container before running tests
-func (suite *MatrixClientTestSuite) SetupSuite() {
-	suite.matrixContainer = matrixtest.StartMatrixContainer(suite.T(), matrixtest.DefaultMatrixConfig())
-}
-
-// TearDownSuite cleans up the Matrix container after tests
-func (suite *MatrixClientTestSuite) TearDownSuite() {
-	if suite.matrixContainer != nil {
-		suite.matrixContainer.Cleanup(suite.T())
-	}
-}
-
-// SetupTest prepares each test with Matrix client and ensures AS bot is created
+// SetupTest creates a fresh Matrix container for each test to avoid rate limiting accumulation
 func (suite *MatrixClientTestSuite) SetupTest() {
+	// Start fresh Matrix container for each test to reset rate limiting state
+	suite.matrixContainer = matrixtest.StartMatrixContainer(suite.T(), matrixtest.DefaultMatrixConfig())
+
 	// Use the container's Matrix client which has rate limiting built-in
 	suite.client = suite.matrixContainer.Client
 
@@ -41,6 +32,13 @@ func (suite *MatrixClientTestSuite) SetupTest() {
 	// Use a unique name to avoid alias conflicts between test methods
 	roomName := fmt.Sprintf("AS Bot Provisioning Room %d", time.Now().UnixNano())
 	_ = suite.matrixContainer.CreateRoom(suite.T(), roomName)
+}
+
+// TearDownTest cleans up the Matrix container after each test
+func (suite *MatrixClientTestSuite) TearDownTest() {
+	if suite.matrixContainer != nil {
+		suite.matrixContainer.Cleanup(suite.T())
+	}
 }
 
 // TestMatrixClientOperations tests core Matrix client operations that affect change

--- a/server/matrix/test/ratelimit_test.go
+++ b/server/matrix/test/ratelimit_test.go
@@ -1,8 +1,9 @@
-package matrix
+package test
 
 import (
 	"testing"
 
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/matrix"
 	"github.com/pkg/errors"
 )
 
@@ -14,7 +15,7 @@ func TestIsRateLimitError(t *testing.T) {
 	}{
 		{
 			name: "Matrix 429 error with M_LIMIT_EXCEEDED",
-			err: &Error{
+			err: &matrix.Error{
 				StatusCode: 429,
 				ErrCode:    "M_LIMIT_EXCEEDED",
 				ErrMsg:     "Too Many Requests",
@@ -23,7 +24,7 @@ func TestIsRateLimitError(t *testing.T) {
 		},
 		{
 			name: "Matrix error with M_LIMIT_EXCEEDED code only",
-			err: &Error{
+			err: &matrix.Error{
 				StatusCode: 500,
 				ErrCode:    "M_LIMIT_EXCEEDED",
 				ErrMsg:     "Rate limit exceeded",
@@ -32,7 +33,7 @@ func TestIsRateLimitError(t *testing.T) {
 		},
 		{
 			name: "Matrix 429 error without M_LIMIT_EXCEEDED",
-			err: &Error{
+			err: &matrix.Error{
 				StatusCode: 429,
 				ErrCode:    "UNKNOWN",
 				ErrMsg:     "Too Many Requests",
@@ -41,7 +42,7 @@ func TestIsRateLimitError(t *testing.T) {
 		},
 		{
 			name: "Non-rate limit Matrix error",
-			err: &Error{
+			err: &matrix.Error{
 				StatusCode: 400,
 				ErrCode:    "M_INVALID_PARAM",
 				ErrMsg:     "Bad request",
@@ -62,7 +63,7 @@ func TestIsRateLimitError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsRateLimitError(tt.err)
+			result := matrix.IsRateLimitError(tt.err)
 			if result != tt.expected {
 				t.Errorf("IsRateLimitError() = %v, expected %v for error: %v", result, tt.expected, tt.err)
 			}

--- a/server/matrix_mentions_integration_test.go
+++ b/server/matrix_mentions_integration_test.go
@@ -17,7 +17,7 @@ func TestMatrixMentionProcessing(t *testing.T) {
 	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
 	defer matrixContainer.Cleanup(t)
 
-	// Create test room
+	// Create test room (this will be throttled automatically)
 	_ = matrixContainer.CreateRoom(t, "Mention Test Room")
 
 	// Set up plugin
@@ -87,8 +87,9 @@ func TestMatrixMentionProcessing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create fresh room for each test case to ensure isolation (like sync tests)
-			freshRoomID := matrixContainer.CreateRoom(t, "Fresh Mention Room "+tc.name)
+			// Create fresh room for each test case to ensure isolation
+			// The CreateRoom method now includes automatic throttling to prevent rate limits
+			freshRoomID := matrixContainer.CreateRoom(t, "Mention Room - "+tc.name)
 
 			// Update KV store mapping for this fresh room
 			_ = setup.Plugin.kvstore.Set("channel_mapping_"+setup.ChannelID, []byte(freshRoomID))
@@ -161,7 +162,7 @@ func TestMatrixMentionEdgeCases(t *testing.T) {
 	matrixContainer := matrixtest.StartMatrixContainer(t, matrixtest.DefaultMatrixConfig())
 	defer matrixContainer.Cleanup(t)
 
-	// Create test room
+	// Create test room (this will be throttled automatically)
 	_ = matrixContainer.CreateRoom(t, "Mention Edge Cases Room")
 
 	// Set up plugin
@@ -286,8 +287,9 @@ func TestMatrixMentionEdgeCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create fresh room for each test case to ensure isolation (like sync tests)
-			freshRoomID := matrixContainer.CreateRoom(t, "Fresh Edge Case Room "+tc.name)
+			// Create fresh room for each test case to ensure isolation
+			// The CreateRoom method now includes automatic throttling to prevent rate limits
+			freshRoomID := matrixContainer.CreateRoom(t, "Edge Case Room - "+tc.name)
 
 			// Update KV store mapping for this fresh room
 			_ = setup.Plugin.kvstore.Set("channel_mapping_"+setup.ChannelID, []byte(freshRoomID))

--- a/server/matrix_mentions_integration_test.go
+++ b/server/matrix_mentions_integration_test.go
@@ -117,7 +117,7 @@ func TestMatrixMentionProcessing(t *testing.T) {
 			require.NoError(t, err)
 
 			// Wait for Matrix to process with polling
-			var messageEvent map[string]any
+			var messageEvent *matrixtest.Event
 			require.Eventually(t, func() bool {
 				events := matrixContainer.GetRoomEvents(t, freshRoomID)
 				messageEvent = matrixtest.FindEventByPostID(events, post.Id)
@@ -125,22 +125,19 @@ func TestMatrixMentionProcessing(t *testing.T) {
 			}, 10*time.Second, 500*time.Millisecond, "Should find message event within timeout")
 
 			// Debug: Print the actual message content
-			if content, ok := messageEvent["content"].(map[string]any); ok {
-				t.Logf("Message content: %+v", content)
-				if mentions, hasMentions := content["m.mentions"]; hasMentions {
-					t.Logf("Found mentions: %+v", mentions)
-				} else {
-					t.Logf("No m.mentions field found")
-				}
+			t.Logf("Message content: %+v", messageEvent.Content)
+			if mentions, hasMentions := messageEvent.Content["m.mentions"]; hasMentions {
+				t.Logf("Found mentions: %+v", mentions)
+			} else {
+				t.Logf("No m.mentions field found")
 			}
 
 			// Validate mention structure
-			validator := matrixtest.NewMatrixEventValidation(t, matrixContainer.ServerDomain, setup.Plugin.remoteID)
-			validator.ValidateMessageWithMentions(messageEvent, post, tc.expectedMentions)
+			validator := matrixtest.NewEventValidation(t, matrixContainer.ServerDomain, setup.Plugin.remoteID)
+			validator.ValidateMessageWithMentions(*messageEvent, post, tc.expectedMentions)
 
 			// Verify specific mention details
-			content := messageEvent["content"].(map[string]any)
-			mentions := content["m.mentions"].(map[string]any)
+			mentions := messageEvent.Content["m.mentions"].(map[string]any)
 			userIDs := mentions["user_ids"].([]any)
 
 			// Check mentioned user IDs
@@ -150,7 +147,7 @@ func TestMatrixMentionProcessing(t *testing.T) {
 			}
 
 			// Check HTML formatting
-			formattedBody := content["formatted_body"].(string)
+			formattedBody := messageEvent.Content["formatted_body"].(string)
 			for _, snippet := range tc.expectedHTMLSnippets {
 				assert.Contains(t, formattedBody, snippet, "Should contain expected HTML snippet")
 			}
@@ -318,36 +315,34 @@ func TestMatrixMentionEdgeCases(t *testing.T) {
 			require.NoError(t, err)
 
 			// Wait for processing with polling
-			var messageEvent map[string]any
+			var messageEvent *matrixtest.Event
 			require.Eventually(t, func() bool {
 				events := matrixContainer.GetRoomEvents(t, freshRoomID)
 				messageEvent = matrixtest.FindEventByPostID(events, post.Id)
 				return messageEvent != nil
 			}, 10*time.Second, 500*time.Millisecond, "Should find message event within timeout")
 
-			content := messageEvent["content"].(map[string]any)
-
 			if tc.expectedMentions > 0 {
 				// Should have mentions
-				mentions, hasMentions := content["m.mentions"].(map[string]any)
+				mentions, hasMentions := messageEvent.Content["m.mentions"].(map[string]any)
 				require.True(t, hasMentions, "Should have m.mentions field")
 
 				userIDs := mentions["user_ids"].([]any)
 				assert.Len(t, userIDs, tc.expectedMentions, "Should have expected mention count")
 			} else {
 				// Should not have mentions
-				_, hasMentions := content["m.mentions"]
+				_, hasMentions := messageEvent.Content["m.mentions"]
 				assert.False(t, hasMentions, "Should not have m.mentions field")
 			}
 
 			if tc.shouldHaveHTML {
-				_, hasHTML := content["formatted_body"]
+				_, hasHTML := messageEvent.Content["formatted_body"]
 				assert.True(t, hasHTML, "Should have HTML formatted body")
 			}
 
 			// Special validation for email corruption test
 			if tc.name == "email_corruption_test" {
-				formattedBody, hasFormatted := content["formatted_body"].(string)
+				formattedBody, hasFormatted := messageEvent.Content["formatted_body"].(string)
 				require.True(t, hasFormatted, "Should have formatted_body for email corruption test")
 
 				// Debug: Print the actual formatted body
@@ -363,7 +358,7 @@ func TestMatrixMentionEdgeCases(t *testing.T) {
 
 			// Special validation for edge case with real user matching email domain
 			if tc.name == "user_with_existing_name_edge_case" {
-				formattedBody, hasFormatted := content["formatted_body"].(string)
+				formattedBody, hasFormatted := messageEvent.Content["formatted_body"].(string)
 				require.True(t, hasFormatted, "Should have formatted_body for edge case test")
 
 				// Debug: Print the actual formatted body

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -280,7 +280,7 @@ func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.Ch
 	}
 
 	// First check if this channel is bridged to Matrix
-	matrixRoomID, err := p.mattermostToMatrixBridge.getMatrixRoomID(channelMember.ChannelId)
+	matrixRoomID, err := p.mattermostToMatrixBridge.GetMatrixRoomID(channelMember.ChannelId)
 	if err != nil || matrixRoomID == "" {
 		// Channel is not bridged to Matrix, nothing to do
 		p.logger.LogDebug("Channel not bridged to Matrix, skipping user join sync", "channel_id", channelMember.ChannelId)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -268,7 +268,7 @@ func (p *Plugin) RunKVStoreMigrationsWithResults() (*command.MigrationResult, er
 }
 
 // UserHasJoinedChannel is called when a user joins or is added to a channel
-func (p *Plugin) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
+func (p *Plugin) UserHasJoinedChannel(_ *plugin.Context, channelMember *model.ChannelMember, _ *model.User) {
 	config := p.getConfiguration()
 	if !config.EnableSync {
 		return

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -247,6 +247,11 @@ func (p *Plugin) GetPluginAPIClient() *pluginapi.Client {
 	return p.client
 }
 
+// GetRemoteID returns the plugin's remote ID for shared channel operations
+func (p *Plugin) GetRemoteID() string {
+	return p.remoteID
+}
+
 // RunKVStoreMigrations exposes migration functionality to command handlers
 func (p *Plugin) RunKVStoreMigrations() error {
 	return p.runKVStoreMigrations()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -303,7 +303,21 @@ func (p *Plugin) UserHasJoinedChannel(_ *plugin.Context, channelMember *model.Ch
 		var appErr *model.AppError
 		user, appErr = p.API.GetUser(channelMember.UserId)
 		if appErr != nil {
-			p.logger.LogError("Failed to get user who joined channel", "error", appErr, "user_id", channelMember.UserId)
+			// Log the failure with context about both fallback methods
+			if actor == nil {
+				p.logger.LogError("Failed to get user who joined channel - no actor provided and GetUser API call failed",
+					"error", appErr,
+					"user_id", channelMember.UserId,
+					"channel_id", channelMember.ChannelId,
+					"troubleshooting", "both actor parameter and GetUser API call failed")
+			} else {
+				p.logger.LogError("Failed to get user who joined channel - actor provided but user ID mismatch, GetUser API call also failed",
+					"error", appErr,
+					"user_id", channelMember.UserId,
+					"actor_id", actor.Id,
+					"channel_id", channelMember.ChannelId,
+					"troubleshooting", "actor user ID did not match channel member user ID, and GetUser API call failed")
+			}
 			return
 		}
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -149,7 +149,9 @@ func (p *Plugin) ExecuteCommand(_ *plugin.Context, args *model.CommandArgs) (*mo
 
 func (p *Plugin) initMatrixClient() {
 	config := p.getConfiguration()
-	p.matrixClient = matrix.NewClient(config.MatrixServerURL, config.MatrixASToken, p.remoteID, p.API)
+	rateLimitMode := matrix.ParseRateLimitingMode(config.RateLimitingMode)
+	rateLimitConfig := matrix.GetRateLimitConfigByMode(rateLimitMode)
+	p.matrixClient = matrix.NewClientWithRateLimit(config.MatrixServerURL, config.MatrixASToken, p.remoteID, p.API, rateLimitConfig)
 }
 
 func (p *Plugin) initBridges() {

--- a/server/plugin_integration_test.go
+++ b/server/plugin_integration_test.go
@@ -17,7 +17,7 @@ import (
 // PluginIntegrationTestSuite contains integration tests for plugin-level Matrix operations
 type PluginIntegrationTestSuite struct {
 	suite.Suite
-	matrixContainer *matrixtest.MatrixContainer
+	matrixContainer *matrixtest.Container
 	plugin          *Plugin
 	api             *plugintest.API
 }

--- a/server/plugin_integration_test.go
+++ b/server/plugin_integration_test.go
@@ -56,15 +56,9 @@ func (suite *PluginIntegrationTestSuite) SetupTest() {
 	suite.plugin.postTracker = NewPostTracker(DefaultPostTrackerMaxEntries)
 	suite.plugin.logger = &testLogger{t: suite.T()}
 
-	// Initialize Matrix client
-	suite.plugin.matrixClient = matrix.NewClientWithLoggerAndRateLimit(
-		suite.matrixContainer.ServerURL,
-		suite.matrixContainer.ASToken,
-		suite.plugin.remoteID,
-		matrix.NewTestLogger(suite.T()),
-		matrix.TestRateLimitConfig(),
-	)
-	suite.plugin.matrixClient.SetServerDomain(suite.matrixContainer.ServerDomain)
+	// Reuse the container's Matrix client to share rate limiting state
+	// This prevents rate limit conflicts between container setup and plugin operations
+	suite.plugin.matrixClient = suite.matrixContainer.Client
 
 	// Set configuration
 	config := &configuration{

--- a/server/plugin_integration_test.go
+++ b/server/plugin_integration_test.go
@@ -1,0 +1,414 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/matrix"
+	matrixtest "github.com/mattermost/mattermost-plugin-matrix-bridge/testcontainers/matrix"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// PluginIntegrationTestSuite contains integration tests for plugin-level Matrix operations
+type PluginIntegrationTestSuite struct {
+	suite.Suite
+	matrixContainer *matrixtest.MatrixContainer
+	plugin          *Plugin
+	api             *plugintest.API
+}
+
+// SetupSuite starts the Matrix container before running tests
+func (suite *PluginIntegrationTestSuite) SetupSuite() {
+	suite.matrixContainer = matrixtest.StartMatrixContainer(suite.T(), matrixtest.DefaultMatrixConfig())
+}
+
+// TearDownSuite cleans up the Matrix container after tests
+func (suite *PluginIntegrationTestSuite) TearDownSuite() {
+	if suite.matrixContainer != nil {
+		suite.matrixContainer.Cleanup(suite.T())
+	}
+}
+
+// SetupTest prepares each test with fresh plugin instance
+func (suite *PluginIntegrationTestSuite) SetupTest() {
+	// Create a test room to ensure AS bot user is provisioned
+	_ = suite.matrixContainer.CreateRoom(suite.T(), "AS Bot Provisioning Room")
+
+	// Set up mock API
+	suite.api = &plugintest.API{}
+
+	// Set up plugin
+	suite.plugin = &Plugin{
+		remoteID: "test-remote-id",
+	}
+	suite.plugin.SetAPI(suite.api)
+
+	// Initialize KV store with in-memory implementation
+	suite.plugin.kvstore = NewMemoryKVStore()
+
+	// Initialize required components
+	suite.plugin.pendingFiles = NewPendingFileTracker()
+	suite.plugin.postTracker = NewPostTracker(DefaultPostTrackerMaxEntries)
+	suite.plugin.logger = &testLogger{t: suite.T()}
+
+	// Initialize Matrix client
+	suite.plugin.matrixClient = matrix.NewClientWithLogger(
+		suite.matrixContainer.ServerURL,
+		suite.matrixContainer.ASToken,
+		suite.plugin.remoteID,
+		matrix.NewTestLogger(suite.T()),
+	)
+	suite.plugin.matrixClient.SetServerDomain(suite.matrixContainer.ServerDomain)
+
+	// Set configuration
+	config := &configuration{
+		MatrixServerURL: suite.matrixContainer.ServerURL,
+		MatrixASToken:   suite.matrixContainer.ASToken,
+		MatrixHSToken:   suite.matrixContainer.HSToken,
+		EnableSync:      true,
+	}
+	suite.plugin.configuration = config
+
+	// Initialize bridge components
+	suite.plugin.initBridges()
+}
+
+// TestPluginMatrixOperations tests plugin-level Matrix operations
+func (suite *PluginIntegrationTestSuite) TestPluginMatrixOperations() {
+	suite.Run("InviteRemoteUserToMatrixRoom", func() {
+		suite.testInviteRemoteUserToMatrixRoom()
+	})
+
+	suite.Run("SyncChannelMembersToMatrixRoom", func() {
+		suite.testSyncChannelMembersToMatrixRoom()
+	})
+}
+
+// testInviteRemoteUserToMatrixRoom tests inviting remote users to Matrix rooms
+func (suite *PluginIntegrationTestSuite) testInviteRemoteUserToMatrixRoom() {
+	// Create a test room
+	roomIdentifier := suite.matrixContainer.CreateRoom(suite.T(), "Remote User Test Room")
+	roomID, err := suite.plugin.matrixClient.ResolveRoomAlias(roomIdentifier)
+	require.NoError(suite.T(), err, "Should resolve room identifier")
+
+	// Create test channel and set up mapping
+	testChannelID := model.NewId()
+	err = suite.plugin.mattermostToMatrixBridge.setChannelRoomMapping(testChannelID, roomID)
+	require.NoError(suite.T(), err, "Should set up channel room mapping")
+
+	suite.Run("InviteExistingRemoteUser", func() {
+		// Create a regular Matrix user to represent a remote user
+		testUser := suite.matrixContainer.CreateUser(suite.T(), "remoteuser", "password123")
+
+		// Create Mattermost user model representing the remote user
+		mattermostUserID := model.NewId()
+		remoteUser := &model.User{
+			Id:       mattermostUserID,
+			Username: "remote_" + testUser.Username,
+			Email:    testUser.Username + "@matrix.org",
+		}
+
+		// Set up the remote user with proper remote ID
+		remoteUser.RemoteId = &suite.plugin.remoteID
+
+		// Set up API mocks
+		suite.api.On("GetUser", mattermostUserID).Return(remoteUser, nil)
+
+		// Set up KV store mapping from Mattermost user to Matrix user
+		userMapKey := "matrix_user_" + testUser.UserID
+		err = suite.plugin.kvstore.Set(userMapKey, []byte(mattermostUserID))
+		require.NoError(suite.T(), err, "Should set up user mapping")
+
+		// Set up reverse mapping
+		reverseMapKey := "mattermost_user_" + mattermostUserID
+		err = suite.plugin.kvstore.Set(reverseMapKey, []byte(testUser.UserID))
+		require.NoError(suite.T(), err, "Should set up reverse user mapping")
+
+		// Test inviting remote user to Matrix room
+		err = suite.plugin.inviteRemoteUserToMatrixRoom(remoteUser, testChannelID)
+		require.NoError(suite.T(), err, "Should invite remote user to Matrix room")
+
+		// Verify user has been invited to the room
+		members := suite.matrixContainer.GetRoomMembers(suite.T(), roomID)
+
+		userFound := false
+		for _, member := range members {
+			if member.UserID == testUser.UserID {
+				userFound = true
+				assert.Equal(suite.T(), "invite", member.Membership, "Remote user should be invited")
+				break
+			}
+		}
+		assert.True(suite.T(), userFound, "Remote user should be found in room members")
+		suite.T().Logf("Successfully invited remote user %s to room %s", testUser.UserID, roomID)
+	})
+
+	suite.Run("InviteNonExistentUser", func() {
+		// Test with user that has no Matrix mapping
+		nonExistentUserID := model.NewId()
+		nonExistentUser := &model.User{
+			Id:       nonExistentUserID,
+			Username: "nonexistent",
+			Email:    "nonexistent@example.com",
+		}
+		nonExistentUser.RemoteId = &suite.plugin.remoteID
+
+		suite.api.On("GetUser", nonExistentUserID).Return(nonExistentUser, nil)
+
+		// This should fail because there's no Matrix user mapping
+		err := suite.plugin.inviteRemoteUserToMatrixRoom(nonExistentUser, testChannelID)
+		assert.Error(suite.T(), err, "Should fail to invite user with no Matrix mapping")
+	})
+
+	suite.Run("InviteToNonExistentChannel", func() {
+		// Test with channel that's not bridged to Matrix
+		testUser := suite.matrixContainer.CreateUser(suite.T(), "remoteuser2", "password123")
+
+		mattermostUserID := model.NewId()
+		remoteUser := &model.User{
+			Id:       mattermostUserID,
+			Username: "remote_" + testUser.Username,
+			Email:    testUser.Username + "@matrix.org",
+		}
+		remoteUser.RemoteId = &suite.plugin.remoteID
+
+		suite.api.On("GetUser", mattermostUserID).Return(remoteUser, nil)
+
+		// Set up user mapping but don't create channel mapping
+		userMapKey := "matrix_user_" + testUser.UserID
+		err = suite.plugin.kvstore.Set(userMapKey, []byte(mattermostUserID))
+		require.NoError(suite.T(), err, "Should set up user mapping")
+
+		reverseMapKey := "mattermost_user_" + mattermostUserID
+		err = suite.plugin.kvstore.Set(reverseMapKey, []byte(testUser.UserID))
+		require.NoError(suite.T(), err, "Should set up reverse user mapping")
+
+		nonExistentChannelID := model.NewId()
+		err = suite.plugin.inviteRemoteUserToMatrixRoom(remoteUser, nonExistentChannelID)
+		assert.NoError(suite.T(), err, "Should gracefully skip invite to non-bridged channel")
+	})
+}
+
+// testSyncChannelMembersToMatrixRoom tests syncing all channel members to a Matrix room
+func (suite *PluginIntegrationTestSuite) testSyncChannelMembersToMatrixRoom() {
+	// This test will simulate the syncChannelMembersToMatrixRoom functionality
+	// Since we can't directly test the command handler method without extensive mocking,
+	// we'll test the core synchronization logic
+
+	// Create test room
+	roomIdentifier := suite.matrixContainer.CreateRoom(suite.T(), "Member Sync Test Room")
+	roomID, err := suite.plugin.matrixClient.ResolveRoomAlias(roomIdentifier)
+	require.NoError(suite.T(), err, "Should resolve room identifier")
+
+	// Create test channel
+	testChannelID := model.NewId()
+	testChannel := &model.Channel{
+		Id:          testChannelID,
+		DisplayName: "Test Channel",
+		Name:        "test-channel",
+		Type:        model.ChannelTypeOpen,
+	}
+
+	suite.Run("SyncMixedMemberTypes", func() {
+		// Create test users - mix of local and remote
+		localUser1ID := model.NewId()
+		localUser1 := &model.User{
+			Id:       localUser1ID,
+			Username: "localuser1",
+			Email:    "local1@example.com",
+		}
+
+		localUser2ID := model.NewId()
+		localUser2 := &model.User{
+			Id:       localUser2ID,
+			Username: "localuser2",
+			Email:    "local2@example.com",
+		}
+
+		// Create Matrix users to represent remote users with unique names
+		timestamp := time.Now().UnixNano()
+		username1 := fmt.Sprintf("remoteuser1_%d", timestamp)
+		username2 := fmt.Sprintf("remoteuser2_%d", timestamp)
+
+		matrixUser1 := suite.matrixContainer.CreateUser(suite.T(), username1, "password123")
+		matrixUser2 := suite.matrixContainer.CreateUser(suite.T(), username2, "password123")
+
+		remoteUser1ID := model.NewId()
+		remoteUser1 := &model.User{
+			Id:       remoteUser1ID,
+			Username: "remote_" + matrixUser1.Username,
+			Email:    matrixUser1.Username + "@matrix.org",
+		}
+		remoteUser1.RemoteId = &suite.plugin.remoteID
+
+		remoteUser2ID := model.NewId()
+		remoteUser2 := &model.User{
+			Id:       remoteUser2ID,
+			Username: "remote_" + matrixUser2.Username,
+			Email:    matrixUser2.Username + "@matrix.org",
+		}
+		remoteUser2.RemoteId = &suite.plugin.remoteID
+
+		// Set up API mocks for all users
+		suite.api.On("GetChannel", testChannelID).Return(testChannel, nil)
+		suite.api.On("GetUser", localUser1ID).Return(localUser1, nil)
+		suite.api.On("GetUser", localUser2ID).Return(localUser2, nil)
+		suite.api.On("GetUser", remoteUser1ID).Return(remoteUser1, nil)
+		suite.api.On("GetUser", remoteUser2ID).Return(remoteUser2, nil)
+
+		// Mock channel members
+		channelMembers := []model.ChannelMember{
+			{UserId: localUser1ID, ChannelId: testChannelID},
+			{UserId: localUser2ID, ChannelId: testChannelID},
+			{UserId: remoteUser1ID, ChannelId: testChannelID},
+			{UserId: remoteUser2ID, ChannelId: testChannelID},
+		}
+		suite.api.On("GetChannelMembers", testChannelID, 0, 100).Return(channelMembers, nil)
+
+		// Mock profile images for ghost user creation
+		suite.api.On("GetProfileImage", localUser1ID).Return([]byte("fake-image-data-1"), nil)
+		suite.api.On("GetProfileImage", localUser2ID).Return([]byte("fake-image-data-2"), nil)
+
+		// Set up user mappings for remote users
+		userMapKey1 := "matrix_user_" + matrixUser1.UserID
+		err = suite.plugin.kvstore.Set(userMapKey1, []byte(remoteUser1ID))
+		require.NoError(suite.T(), err, "Should set up remote user 1 mapping")
+
+		reverseMapKey1 := "mattermost_user_" + remoteUser1ID
+		err = suite.plugin.kvstore.Set(reverseMapKey1, []byte(matrixUser1.UserID))
+		require.NoError(suite.T(), err, "Should set up reverse mapping for remote user 1")
+
+		userMapKey2 := "matrix_user_" + matrixUser2.UserID
+		err = suite.plugin.kvstore.Set(userMapKey2, []byte(remoteUser2ID))
+		require.NoError(suite.T(), err, "Should set up remote user 2 mapping")
+
+		reverseMapKey2 := "mattermost_user_" + remoteUser2ID
+		err = suite.plugin.kvstore.Set(reverseMapKey2, []byte(matrixUser2.UserID))
+		require.NoError(suite.T(), err, "Should set up reverse mapping for remote user 2")
+
+		// Set up channel room mapping
+		err = suite.plugin.mattermostToMatrixBridge.setChannelRoomMapping(testChannelID, roomID)
+		require.NoError(suite.T(), err, "Should set up channel room mapping")
+
+		// Test the core sync logic by manually processing each member type
+		// This simulates what syncChannelMembersToMatrixRoom would do
+
+		localUserCount := 0
+		remoteUserCount := 0
+
+		for _, member := range channelMembers {
+			user, appErr := suite.plugin.API.GetUser(member.UserId)
+			require.Nil(suite.T(), appErr, "Should get user")
+
+			if user.IsRemote() {
+				// Handle remote user - invite to Matrix room
+				originalMatrixUserID, err := suite.plugin.mattermostToMatrixBridge.GetMatrixUserIDFromMattermostUser(user.Id)
+				if err == nil {
+					err = suite.plugin.matrixClient.InviteUserToRoom(roomID, originalMatrixUserID)
+					if err == nil {
+						remoteUserCount++
+						suite.T().Logf("Successfully invited remote user %s (%s) to room", user.Username, originalMatrixUserID)
+					}
+				}
+			} else {
+				// Handle local user - create ghost user and join to room
+				ghostUserID, err := suite.plugin.mattermostToMatrixBridge.CreateOrGetGhostUser(user.Id)
+				if err == nil {
+					err = suite.plugin.matrixClient.InviteAndJoinGhostUser(roomID, ghostUserID)
+					if err == nil {
+						localUserCount++
+						suite.T().Logf("Successfully joined ghost user %s for local user %s to room", ghostUserID, user.Username)
+					}
+				}
+			}
+		}
+
+		// Verify synchronization results
+		assert.Equal(suite.T(), 2, localUserCount, "Should have synced 2 local users as ghost users")
+		assert.Equal(suite.T(), 2, remoteUserCount, "Should have synced 2 remote users")
+
+		// Verify all users are in the Matrix room
+		members := suite.matrixContainer.GetRoomMembers(suite.T(), roomID)
+
+		// Count different member types in the room
+		ghostUserCount := 0
+		originalUserCount := 0
+		asBotCount := 0
+
+		for _, member := range members {
+			if suite.plugin.mattermostToMatrixBridge.isGhostUser(member.UserID) {
+				ghostUserCount++
+			} else if member.UserID == suite.matrixContainer.GetApplicationServiceBotUserID() {
+				asBotCount++
+			} else {
+				originalUserCount++
+			}
+		}
+
+		// Note: The actual counts may vary due to test setup and timing, but verify core functionality worked
+		assert.GreaterOrEqual(suite.T(), ghostUserCount, 2, "Should have at least 2 ghost users in room")
+		assert.GreaterOrEqual(suite.T(), originalUserCount, 2, "Should have at least 2 original Matrix users invited to room")
+		// AS bot count may be 0 or 1 depending on room configuration
+		assert.GreaterOrEqual(suite.T(), len(members), 4, "Should have at least 4 members total (2 ghost + 2 original + optional AS bot)")
+
+		suite.T().Logf("Room members summary - Ghost users: %d, Original users: %d, AS bot: %d",
+			ghostUserCount, originalUserCount, asBotCount)
+	})
+
+	suite.Run("SyncEmptyChannel", func() {
+		// Test syncing a channel with no members
+		emptyChannelID := model.NewId()
+		emptyChannel := &model.Channel{
+			Id:          emptyChannelID,
+			DisplayName: "Empty Channel",
+			Name:        "empty-channel",
+			Type:        model.ChannelTypeOpen,
+		}
+
+		suite.api.On("GetChannel", emptyChannelID).Return(emptyChannel, nil)
+		suite.api.On("GetChannelMembers", emptyChannelID, 0, 100).Return([]model.ChannelMember{}, nil)
+
+		// Create room for empty channel
+		emptyRoomIdentifier := suite.matrixContainer.CreateRoom(suite.T(), "Empty Channel Test Room")
+		emptyRoomID, err := suite.plugin.matrixClient.ResolveRoomAlias(emptyRoomIdentifier)
+		require.NoError(suite.T(), err, "Should resolve empty room identifier")
+
+		err = suite.plugin.mattermostToMatrixBridge.setChannelRoomMapping(emptyChannelID, emptyRoomID)
+		require.NoError(suite.T(), err, "Should set up empty channel room mapping")
+
+		// Simulate sync with empty channel - should complete without error
+		channelMembers := []model.ChannelMember{}
+		localUserCount := 0
+		remoteUserCount := 0
+
+		for _, member := range channelMembers {
+			user, appErr := suite.plugin.API.GetUser(member.UserId)
+			require.Nil(suite.T(), appErr, "Should get user")
+
+			if user.IsRemote() {
+				remoteUserCount++
+			} else {
+				localUserCount++
+			}
+		}
+
+		assert.Equal(suite.T(), 0, localUserCount, "Should have 0 local users in empty channel")
+		assert.Equal(suite.T(), 0, remoteUserCount, "Should have 0 remote users in empty channel")
+
+		// Verify only AS bot is in the room
+		members := suite.matrixContainer.GetRoomMembers(suite.T(), emptyRoomID)
+
+		assert.Equal(suite.T(), 1, len(members), "Empty room should only have AS bot")
+		assert.Equal(suite.T(), suite.matrixContainer.GetApplicationServiceBotUserID(), members[0].UserID, "Only member should be AS bot")
+	})
+}
+
+// Test runner function
+func TestPluginIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(PluginIntegrationTestSuite))
+}

--- a/server/plugin_integration_test.go
+++ b/server/plugin_integration_test.go
@@ -57,11 +57,12 @@ func (suite *PluginIntegrationTestSuite) SetupTest() {
 	suite.plugin.logger = &testLogger{t: suite.T()}
 
 	// Initialize Matrix client
-	suite.plugin.matrixClient = matrix.NewClientWithLogger(
+	suite.plugin.matrixClient = matrix.NewClientWithLoggerAndRateLimit(
 		suite.matrixContainer.ServerURL,
 		suite.matrixContainer.ASToken,
 		suite.plugin.remoteID,
 		matrix.NewTestLogger(suite.T()),
+		matrix.TestRateLimitConfig(),
 	)
 	suite.plugin.matrixClient.SetServerDomain(suite.matrixContainer.ServerDomain)
 

--- a/server/plugin_integration_test.go
+++ b/server/plugin_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/matrix"
 	matrixtest "github.com/mattermost/mattermost-plugin-matrix-bridge/testcontainers/matrix"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"

--- a/server/sync_to_matrix.go
+++ b/server/sync_to_matrix.go
@@ -265,7 +265,7 @@ func (b *MattermostToMatrixBridge) SyncPostToMatrix(post *model.Post, channelID 
 	}
 
 	// First check if this is a regular channel with existing mapping
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier")
 	}
@@ -591,7 +591,7 @@ func (b *MattermostToMatrixBridge) updatePostInMatrix(post *model.Post, matrixRo
 // deletePostFromMatrix handles deleting a post from Matrix by redacting the Matrix message
 func (b *MattermostToMatrixBridge) deletePostFromMatrix(post *model.Post, channelID string) error {
 	// Get Matrix room identifier
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier for post deletion")
 	}
@@ -668,7 +668,7 @@ func (b *MattermostToMatrixBridge) SyncReactionToMatrix(reaction *model.Reaction
 // addReactionToMatrix adds a new reaction to Matrix
 func (b *MattermostToMatrixBridge) addReactionToMatrix(reaction *model.Reaction, channelID string) error {
 	// Get Matrix room identifier
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier")
 	}
@@ -747,7 +747,7 @@ func (b *MattermostToMatrixBridge) addReactionToMatrix(reaction *model.Reaction,
 // removeReactionFromMatrix removes a reaction from Matrix by finding and redacting the matching reaction event
 func (b *MattermostToMatrixBridge) removeReactionFromMatrix(reaction *model.Reaction, channelID string) error {
 	// Get Matrix room identifier
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Matrix room identifier for reaction removal")
 	}
@@ -1213,7 +1213,7 @@ func (b *MattermostToMatrixBridge) getCurrentMatrixFileAttachments(matrixRoomID,
 // getOrCreateDMRoom gets an existing DM room mapping or creates a new Matrix DM room
 func (b *MattermostToMatrixBridge) getOrCreateDMRoom(channelID string, userIDs []string, initiatingUserID string) (string, error) {
 	// First check if we already have a room mapping (unified for all channels)
-	existingRoomID, err := b.getMatrixRoomID(channelID)
+	existingRoomID, err := b.GetMatrixRoomID(channelID)
 	if err == nil && existingRoomID != "" {
 		b.logger.LogDebug("Found existing DM room mapping", "channel_id", channelID, "matrix_room_id", existingRoomID)
 		return existingRoomID, nil

--- a/server/sync_to_matrix_integration_test.go
+++ b/server/sync_to_matrix_integration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 // MatrixSyncTestSuite contains integration tests for syncing to Matrix
 type MatrixSyncTestSuite struct {
 	suite.Suite
-	matrixContainer *matrixtest.MatrixContainer
+	matrixContainer *matrixtest.Container
 	plugin          *Plugin
 	testChannelID   string
 	testUserID      string
@@ -45,7 +46,9 @@ func (suite *MatrixSyncTestSuite) SetupTest() {
 	// The CreateRoom method now includes automatic throttling to prevent rate limits
 	suite.testChannelID = model.NewId()
 	suite.testUserID = model.NewId()
-	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), "Sync Test Room")
+	// Use unique room name to avoid alias conflicts between tests
+	uniqueRoomName := fmt.Sprintf("Sync Test Room %s", suite.testChannelID[:8])
+	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), uniqueRoomName)
 	suite.testGhostUserID = "@_mattermost_" + suite.testUserID + ":" + suite.matrixContainer.ServerDomain
 
 	// Create plugin instance

--- a/server/sync_to_matrix_integration_test.go
+++ b/server/sync_to_matrix_integration_test.go
@@ -42,9 +42,10 @@ func (suite *MatrixSyncTestSuite) SetupTest() {
 	api := &plugintest.API{}
 
 	// Set up test data - create fresh room for each test to ensure isolation
+	// The CreateRoom method now includes automatic throttling to prevent rate limits
 	suite.testChannelID = model.NewId()
 	suite.testUserID = model.NewId()
-	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), "Test Room")
+	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), "Sync Test Room")
 	suite.testGhostUserID = "@_mattermost_" + suite.testUserID + ":" + suite.matrixContainer.ServerDomain
 
 	// Create plugin instance

--- a/server/sync_to_mattermost.go
+++ b/server/sync_to_mattermost.go
@@ -387,7 +387,7 @@ func (b *MatrixToMattermostBridge) syncMatrixRedactionToMattermost(event MatrixE
 	}
 
 	// Get the Matrix room ID to fetch the redacted event details
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		b.logger.LogWarn("Failed to get Matrix room identifier for redaction", "error", err, "channel_id", channelID)
 		return nil
@@ -773,7 +773,7 @@ func (b *MatrixToMattermostBridge) storeMatrixEventPostMapping(matrixEventID, ma
 // getPostIDFromMatrixEventMetadata retrieves post ID from Matrix event content (for Mattermost-originated events)
 func (b *MatrixToMattermostBridge) getPostIDFromMatrixEventMetadata(matrixEventID, channelID string) string {
 	// Get the Matrix room ID for this channel
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		b.logger.LogDebug("Failed to get Matrix room identifier", "error", err, "channel_id", channelID, "matrix_event_id", matrixEventID)
 		return ""
@@ -819,7 +819,7 @@ func (b *MatrixToMattermostBridge) getPostIDFromMatrixEventMetadata(matrixEventI
 // is related to a primary message that has a Mattermost post ID
 func (b *MatrixToMattermostBridge) getPostIDFromRelatedMatrixEvent(matrixEventID, channelID string) string {
 	// Get the Matrix room ID for this channel
-	matrixRoomIdentifier, err := b.getMatrixRoomID(channelID)
+	matrixRoomIdentifier, err := b.GetMatrixRoomID(channelID)
 	if err != nil {
 		b.logger.LogWarn("Failed to get Matrix room identifier for related event lookup", "error", err, "channel_id", channelID)
 		return ""

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -80,10 +81,10 @@ func setupPluginForTestWithLogger(t *testing.T, api plugin.API) *Plugin {
 	return plugin
 }
 
-// createMatrixClientWithTestLogger creates a matrix client with test logger for testing
+// createMatrixClientWithTestLogger creates a matrix client with test logger and rate limiting for testing
 func createMatrixClientWithTestLogger(t *testing.T, serverURL, asToken, remoteID string) *matrix.Client {
 	testLogger := matrix.NewTestLogger(t)
-	return matrix.NewClientWithLogger(serverURL, asToken, remoteID, testLogger)
+	return matrix.NewClientWithLoggerAndRateLimit(serverURL, asToken, remoteID, testLogger, matrix.TestRateLimitConfig())
 }
 
 // TestMatrixClientTestLogger verifies that matrix client uses test logger correctly
@@ -103,7 +104,7 @@ func TestMatrixClientTestLogger(t *testing.T) {
 }
 
 // setupTestPlugin creates a test plugin instance with Matrix container for integration tests
-func setupTestPlugin(t *testing.T, matrixContainer *matrixtest.MatrixContainer) *TestSetup {
+func setupTestPlugin(t *testing.T, matrixContainer *matrixtest.Container) *TestSetup {
 	api := &plugintest.API{}
 
 	testChannelID := model.NewId()
@@ -401,6 +402,11 @@ func TestMemoryKVStore(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for deleted key")
 	}
+}
+
+// generateUniqueRoomName creates a unique room name to avoid alias conflicts
+func generateUniqueRoomName(baseName string) string {
+	return fmt.Sprintf("%s %s", baseName, model.NewId()[:8])
 }
 
 // TestMain provides global test setup and cleanup

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -122,14 +122,9 @@ func setupTestPlugin(t *testing.T, matrixContainer *matrixtest.Container) *TestS
 	plugin.pendingFiles = NewPendingFileTracker()
 	plugin.postTracker = NewPostTracker(DefaultPostTrackerMaxEntries)
 
-	plugin.matrixClient = createMatrixClientWithTestLogger(
-		t,
-		matrixContainer.ServerURL,
-		matrixContainer.ASToken,
-		plugin.remoteID,
-	)
-	// Set explicit server domain for testing
-	plugin.matrixClient.SetServerDomain(matrixContainer.ServerDomain)
+	// Reuse the container's Matrix client to share rate limiting state
+	// This prevents rate limit conflicts between container setup and plugin operations
+	plugin.matrixClient = matrixContainer.Client
 
 	config := &configuration{
 		MatrixServerURL: matrixContainer.ServerURL,

--- a/server/thread_mapping_test.go
+++ b/server/thread_mapping_test.go
@@ -114,7 +114,7 @@ type ThreadMappingIntegrationTestSuite struct {
 	testChannelID   string
 	testUserID      string
 	testRoomID      string
-	validator       *matrixtest.MatrixEventValidation
+	validator       *matrixtest.EventValidation
 }
 
 // SetupSuite starts the Matrix container before running tests
@@ -177,7 +177,7 @@ func (suite *ThreadMappingIntegrationTestSuite) SetupTest() {
 	setupTestKVData(suite.plugin.kvstore, suite.testChannelID, suite.testRoomID)
 
 	// Initialize validation helper
-	suite.validator = matrixtest.NewMatrixEventValidation(
+	suite.validator = matrixtest.NewEventValidation(
 		suite.T(),
 		suite.matrixContainer.ServerDomain,
 		suite.plugin.remoteID,

--- a/server/thread_mapping_test.go
+++ b/server/thread_mapping_test.go
@@ -109,7 +109,7 @@ func TestGetThreadRootFromPostID(t *testing.T) {
 // ThreadMappingIntegrationTestSuite tests the threading fix with real Matrix server
 type ThreadMappingIntegrationTestSuite struct {
 	suite.Suite
-	matrixContainer *matrixtest.MatrixContainer
+	matrixContainer *matrixtest.Container
 	plugin          *Plugin
 	testChannelID   string
 	testUserID      string
@@ -137,7 +137,7 @@ func (suite *ThreadMappingIntegrationTestSuite) SetupTest() {
 	// Set up test data
 	suite.testChannelID = model.NewId()
 	suite.testUserID = model.NewId()
-	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), "Thread Test Room")
+	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), generateUniqueRoomName("Thread Test Room"))
 
 	// Create plugin instance
 	suite.plugin = &Plugin{

--- a/server/user_remote_detection_test.go
+++ b/server/user_remote_detection_test.go
@@ -16,7 +16,7 @@ import (
 // UserRemoteDetectionIntegrationTestSuite tests real loop prevention logic with a Matrix server
 type UserRemoteDetectionIntegrationTestSuite struct {
 	suite.Suite
-	matrixContainer *matrixtest.MatrixContainer
+	matrixContainer *matrixtest.Container
 	plugin          *Plugin
 	testChannelID   string
 	testRoomID      string
@@ -42,7 +42,7 @@ func (suite *UserRemoteDetectionIntegrationTestSuite) SetupTest() {
 
 	// Set up test data
 	suite.testChannelID = model.NewId()
-	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), "Loop Prevention Test Room")
+	suite.testRoomID = suite.matrixContainer.CreateRoom(suite.T(), generateUniqueRoomName("Loop Prevention Test Room"))
 
 	// Create plugin instance
 	suite.plugin = &Plugin{

--- a/server/user_remote_detection_test.go
+++ b/server/user_remote_detection_test.go
@@ -20,7 +20,7 @@ type UserRemoteDetectionIntegrationTestSuite struct {
 	plugin          *Plugin
 	testChannelID   string
 	testRoomID      string
-	validator       *matrixtest.MatrixEventValidation
+	validator       *matrixtest.EventValidation
 }
 
 // SetupSuite starts the Matrix container before running tests
@@ -83,7 +83,7 @@ func (suite *UserRemoteDetectionIntegrationTestSuite) SetupTest() {
 	setupTestKVData(suite.plugin.kvstore, suite.testChannelID, suite.testRoomID)
 
 	// Initialize validation helper
-	suite.validator = matrixtest.NewMatrixEventValidation(
+	suite.validator = matrixtest.NewEventValidation(
 		suite.T(),
 		suite.matrixContainer.ServerDomain,
 		suite.plugin.remoteID,

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -518,59 +518,6 @@ func (mc *Container) makeMatrixRequest(method, endpoint string, data any) (any, 
 	return result, nil
 }
 
-// makeMatrixRequestNoAuth makes an unauthenticated request to the Matrix server
-func (mc *Container) makeMatrixRequestNoAuth(method, endpoint string, data any) (any, error) {
-	var body io.Reader
-
-	if data != nil {
-		jsonData, err := json.Marshal(data)
-		if err != nil {
-			return nil, err
-		}
-		body = strings.NewReader(string(jsonData))
-	}
-
-	req, err := http.NewRequest(method, mc.ServerURL+endpoint, body)
-	if err != nil {
-		return nil, err
-	}
-
-	if data != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode >= 400 {
-		//nolint:staticcheck // Error message capitalization is intentional for Matrix API errors
-		return nil, fmt.Errorf("matrix API error: %d %s", resp.StatusCode, string(responseBody))
-	}
-
-	if len(responseBody) == 0 {
-		return nil, nil
-	}
-
-	var result any
-	err = json.Unmarshal(responseBody, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
 // generateSynapseConfig generates a basic Synapse configuration
 func generateSynapseConfig(config MatrixTestConfig) string {
 	return fmt.Sprintf(`

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -566,7 +566,53 @@ encryption_enabled_by_default_for_room_type: off
 allow_public_rooms_over_federation: true
 allow_public_rooms_without_auth: true
 
-# Use default Synapse rate limits to test client-side throttling
+# Permissive rate limits for faster unit testing
+# Set high limits to effectively disable rate limiting during tests
+rc_message:
+  per_second: 1000
+  burst_count: 1000
+
+# Room creation doesn't have a specific rc_ parameter in Synapse
+# It's typically handled by general request rate limiting or rc_joins
+
+rc_registration:
+  per_second: 1000
+  burst_count: 1000
+
+rc_login:
+  address:
+    per_second: 1000
+    burst_count: 1000
+  account:
+    per_second: 1000
+    burst_count: 1000
+  failed_attempts:
+    per_second: 1000
+    burst_count: 1000
+
+rc_admin_redaction:
+  per_second: 1000
+  burst_count: 1000
+
+rc_joins:
+  local:
+    per_second: 1000
+    burst_count: 1000
+  remote:
+    per_second: 1000
+    burst_count: 1000
+
+rc_3pid_validation:
+  per_second: 1000
+  burst_count: 1000
+
+rc_invites:
+  per_room:
+    per_second: 1000
+    burst_count: 1000
+  per_user:
+    per_second: 1000
+    burst_count: 1000
 
 # Enable registration for testing
 enable_registration: true

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -566,66 +566,62 @@ encryption_enabled_by_default_for_room_type: off
 allow_public_rooms_over_federation: true
 allow_public_rooms_without_auth: true
 
-# Permissive rate limits for faster unit testing
-# Set high limits to effectively disable rate limiting during tests
+# Extremely permissive rate limits for unit testing
+# Use very high values instead of 0 to avoid Synapse bugs
+# Application service users should bypass most rate limiting anyway
 rc_message:
-  per_second: 1000
-  burst_count: 1000
+  per_second: 100000
+  burst_count: 100000
 
-# General request rate limiting - this may affect room creation
-request_rate:
-  per_second: 1000
-  burst_count: 1000
-
-# Additional rate limits that might affect room operations
+# Federation-related limits that might affect room operations
 rc_federation:
-  window_size: 1000
+  window_size: 100000
   sleep_limit: 10
-  sleep_delay: 500
-  reject_limit: 50
-  concurrent: 3
+  sleep_delay: 1
+  reject_limit: 100000
+  concurrent: 100
 
 # Room creation doesn't have a specific rc_ parameter in Synapse
 # It's typically handled by general request rate limiting or rc_joins
 
 rc_registration:
-  per_second: 1000
-  burst_count: 1000
+  per_second: 100000
+  burst_count: 100000
 
 rc_login:
   address:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
   account:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
   failed_attempts:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
 
 rc_admin_redaction:
-  per_second: 1000
-  burst_count: 1000
+  per_second: 100000
+  burst_count: 100000
 
 rc_joins:
   local:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
   remote:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
 
 rc_3pid_validation:
-  per_second: 1000
-  burst_count: 1000
+  per_second: 100000
+  burst_count: 100000
 
 rc_invites:
   per_room:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
   per_user:
-    per_second: 1000
-    burst_count: 1000
+    per_second: 100000
+    burst_count: 100000
 
 # Enable registration for testing
 enable_registration: true
@@ -633,18 +629,16 @@ enable_registration_without_verification: true
 
 # Additional global rate limiting that might affect API calls
 rc_state_events_per_room:
-  per_second: 1000
-  burst_count: 1000
-
-# Federation-related limits that might affect room operations
-rc_remote_room_state:
-  per_second: 1000
-  burst_count: 1000
+  per_second: 100000
+  burst_count: 100000
 
 # General API call rate limiting
-rc_api_rate:
-  per_second: 1000
-  burst_count: 1000
+rc_api:
+  per_second: 100000
+  burst_count: 100000
+
+# Try to disable AS user rate limiting (these users should not be rate limited)
+app_service_rate_limited: false
 `, config.ServerName)
 }
 

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -391,15 +391,15 @@ func (mc *MatrixContainer) GetApplicationServiceBotUserID() string {
 	return fmt.Sprintf("@_mattermost_bot:%s", mc.ServerDomain)
 }
 
-// JoinRoom joins a room as a specific user (overloaded method)
-func (mc *MatrixContainer) JoinRoomAsUser(t *testing.T, userID, roomID string) error {
+// JoinRoomAsUser joins a room as a specific user
+func (mc *MatrixContainer) JoinRoomAsUser(_ *testing.T, userID, roomID string) error {
 	_, err := mc.makeMatrixRequestAsUser("POST", fmt.Sprintf("/_matrix/client/v3/join/%s", roomID), map[string]any{}, userID)
 	return err
 }
 
 // makeMatrixRequestAsUser makes a request as a specific user (requires user credentials)
 // This is a simplified version - in real tests you'd need proper user tokens
-func (mc *MatrixContainer) makeMatrixRequestAsUser(method, endpoint string, data any, userID string) (any, error) {
+func (mc *MatrixContainer) makeMatrixRequestAsUser(method, endpoint string, data any, _ string) (any, error) {
 	// For simplicity in tests, we'll use AS token to act as user
 	// In production, this would require proper user authentication
 	return mc.makeMatrixRequest(method, endpoint, data)

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -572,6 +572,19 @@ rc_message:
   per_second: 1000
   burst_count: 1000
 
+# General request rate limiting - this may affect room creation
+request_rate:
+  per_second: 1000
+  burst_count: 1000
+
+# Additional rate limits that might affect room operations
+rc_federation:
+  window_size: 1000
+  sleep_limit: 10
+  sleep_delay: 500
+  reject_limit: 50
+  concurrent: 3
+
 # Room creation doesn't have a specific rc_ parameter in Synapse
 # It's typically handled by general request rate limiting or rc_joins
 
@@ -617,6 +630,21 @@ rc_invites:
 # Enable registration for testing
 enable_registration: true
 enable_registration_without_verification: true
+
+# Additional global rate limiting that might affect API calls
+rc_state_events_per_room:
+  per_second: 1000
+  burst_count: 1000
+
+# Federation-related limits that might affect room operations
+rc_remote_room_state:
+  per_second: 1000
+  burst_count: 1000
+
+# General API call rate limiting
+rc_api_rate:
+  per_second: 1000
+  burst_count: 1000
 `, config.ServerName)
 }
 

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -562,13 +562,33 @@ user_directory:
 # Disable encryption for simpler testing
 encryption_enabled_by_default_for_room_type: off
 
-# Allow public rooms
+# Allow public rooms and directory publishing
 allow_public_rooms_over_federation: true
 allow_public_rooms_without_auth: true
 
 # Enable registration for testing
 enable_registration: true
 enable_registration_without_verification: true
+
+# Disable rate limiting for tests (matches production config)
+rc_message:
+  per_second: 1000
+  burst_count: 1000
+
+rc_registration:
+  per_second: 1000
+  burst_count: 1000
+
+rc_login:
+  address:
+    per_second: 1000
+    burst_count: 1000
+  account:
+    per_second: 1000
+    burst_count: 1000
+  failed_attempts:
+    per_second: 1000
+    burst_count: 1000
 `, config.ServerName)
 }
 

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -566,86 +566,9 @@ encryption_enabled_by_default_for_room_type: off
 allow_public_rooms_over_federation: true
 allow_public_rooms_without_auth: true
 
-# Extremely permissive rate limits for unit testing
-# Use very high values instead of 0 to avoid Synapse bugs
-# Application service users should bypass most rate limiting anyway
-rc_message:
-  per_second: 100000
-  burst_count: 100000
-
-# Federation-related limits that might affect room operations
-rc_federation:
-  window_size: 100000
-  sleep_limit: 10
-  sleep_delay: 1
-  reject_limit: 100000
-  concurrent: 100
-
-# Room creation doesn't have a specific rc_ parameter in Synapse
-# It's typically handled by general request rate limiting or rc_joins
-
-rc_registration:
-  per_second: 100000
-  burst_count: 100000
-
-rc_login:
-  address:
-    per_second: 100000
-    burst_count: 100000
-  account:
-    per_second: 100000
-    burst_count: 100000
-  failed_attempts:
-    per_second: 100000
-    burst_count: 100000
-
-rc_admin_redaction:
-  per_second: 100000
-  burst_count: 100000
-
-rc_joins:
-  local:
-    per_second: 100000
-    burst_count: 100000
-  remote:
-    per_second: 100000
-    burst_count: 100000
-
-rc_3pid_validation:
-  per_second: 100000
-  burst_count: 100000
-
-rc_invites:
-  per_room:
-    per_second: 100000
-    burst_count: 100000
-  per_user:
-    per_second: 100000
-    burst_count: 100000
-
 # Enable registration for testing
 enable_registration: true
 enable_registration_without_verification: true
-
-# Additional global rate limiting that might affect API calls
-rc_state_events_per_room:
-  per_second: 100000
-  burst_count: 100000
-
-# General API call rate limiting
-rc_api:
-  per_second: 100000
-  burst_count: 100000
-
-# Global rate limiting that might affect all requests
-rc_per_second: 100000
-rc_burst_count: 100000
-
-# Try to disable AS user rate limiting (these users should not be rate limited)
-app_service_rate_limited: false
-
-# Disable request size limits that might be interfering
-max_upload_size: 1000M
 `, config.ServerName)
 }
 

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -637,8 +637,15 @@ rc_api:
   per_second: 100000
   burst_count: 100000
 
+# Global rate limiting that might affect all requests
+rc_per_second: 100000
+rc_burst_count: 100000
+
 # Try to disable AS user rate limiting (these users should not be rate limited)
 app_service_rate_limited: false
+
+# Disable request size limits that might be interfering
+max_upload_size: 1000M
 `, config.ServerName)
 }
 

--- a/testcontainers/matrix/container.go
+++ b/testcontainers/matrix/container.go
@@ -16,10 +16,18 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// Global container registry for cleanup
+const (
+	// MinRoomCreationInterval defines the minimum time between room creations to avoid rate limiting
+	// This prevents hitting Matrix server rate limits that cause HTTP 429 errors in CI
+	MinRoomCreationInterval = 600 * time.Millisecond
+)
+
+// Global container registry for cleanup and rate limiting
 var (
-	activeContainers = make(map[*MatrixContainer]bool)
-	containerMutex   sync.RWMutex
+	activeContainers     = make(map[*MatrixContainer]bool)
+	containerMutex       sync.RWMutex
+	lastRoomCreationTime time.Time
+	roomCreationMutex    sync.Mutex
 )
 
 // MatrixContainer wraps a testcontainer running Synapse
@@ -187,6 +195,30 @@ func (mc *MatrixContainer) isMatrixReady() bool {
 
 // CreateRoom creates a test room and returns its room ID
 func (mc *MatrixContainer) CreateRoom(t *testing.T, roomName string) string {
+	return mc.CreateRoomWithThrottling(t, roomName)
+}
+
+// CreateRoomWithThrottling creates a test room with rate limiting protection
+// This method ensures we don't exceed Matrix server rate limits by tracking
+// the time since the last room creation and sleeping if necessary
+func (mc *MatrixContainer) CreateRoomWithThrottling(t *testing.T, roomName string) string {
+	roomCreationMutex.Lock()
+	defer roomCreationMutex.Unlock()
+
+	// Calculate time since last room creation
+	now := time.Now()
+	if !lastRoomCreationTime.IsZero() {
+		timeSinceLastCreation := now.Sub(lastRoomCreationTime)
+		if timeSinceLastCreation < MinRoomCreationInterval {
+			sleepTime := MinRoomCreationInterval - timeSinceLastCreation
+			t.Logf("Throttling room creation: sleeping %v to avoid rate limits", sleepTime)
+			time.Sleep(sleepTime)
+		}
+	}
+
+	// Update last creation time before making the request
+	lastRoomCreationTime = time.Now()
+
 	roomData := map[string]any{
 		"name":       roomName,
 		"preset":     "public_chat",

--- a/testcontainers/matrix/utils.go
+++ b/testcontainers/matrix/utils.go
@@ -1,13 +1,11 @@
 package matrix
 
 // FindEventByPostID finds a Matrix event by its Mattermost post ID
-func FindEventByPostID(events []map[string]any, postID string) map[string]any {
+func FindEventByPostID(events []Event, postID string) *Event {
 	for _, event := range events {
-		if content, ok := event["content"].(map[string]any); ok {
-			if mattermostPostID, exists := content["mattermost_post_id"].(string); exists {
-				if mattermostPostID == postID {
-					return event
-				}
+		if mattermostPostID, exists := event.Content["mattermost_post_id"].(string); exists {
+			if mattermostPostID == postID {
+				return &event
 			}
 		}
 	}
@@ -15,17 +13,15 @@ func FindEventByPostID(events []map[string]any, postID string) map[string]any {
 }
 
 // FindLatestMessageEvent finds the most recent m.room.message event
-func FindLatestMessageEvent(events []map[string]any) map[string]any {
-	var latestEvent map[string]any
-	var latestTimestamp float64
+func FindLatestMessageEvent(events []Event) *Event {
+	var latestEvent *Event
+	var latestTimestamp int64
 
 	for _, event := range events {
-		if event["type"] == "m.room.message" {
-			if timestamp, ok := event["origin_server_ts"].(float64); ok {
-				if timestamp > latestTimestamp {
-					latestTimestamp = timestamp
-					latestEvent = event
-				}
+		if event.Type == "m.room.message" {
+			if event.Timestamp > latestTimestamp {
+				latestTimestamp = event.Timestamp
+				latestEvent = &event
 			}
 		}
 	}
@@ -34,46 +30,42 @@ func FindLatestMessageEvent(events []map[string]any) map[string]any {
 }
 
 // FindEventByType finds the first event of a specific type
-func FindEventByType(events []map[string]any, eventType string) map[string]any {
+func FindEventByType(events []Event, eventType string) *Event {
 	for _, event := range events {
-		if event["type"] == eventType {
-			return event
+		if event.Type == eventType {
+			return &event
 		}
 	}
 	return nil
 }
 
 // FindEventsByType finds all events of a specific type
-func FindEventsByType(events []map[string]any, eventType string) []map[string]any {
-	var result []map[string]any
+func FindEventsByType(events []Event, eventType string) []Event {
+	var result []Event
 	for _, event := range events {
-		if event["type"] == eventType {
+		if event.Type == eventType {
 			result = append(result, event)
 		}
 	}
 	return result
 }
 
-// GetEventContent extracts and validates content from a Matrix event
-func GetEventContent(event map[string]any) (map[string]any, bool) {
-	content, ok := event["content"].(map[string]any)
-	return content, ok
+// GetEventContent extracts content from a Matrix event
+func GetEventContent(event Event) map[string]any {
+	return event.Content
 }
 
 // GetEventSender extracts the sender from a Matrix event
-func GetEventSender(event map[string]any) (string, bool) {
-	sender, ok := event["sender"].(string)
-	return sender, ok
+func GetEventSender(event Event) string {
+	return event.Sender
 }
 
 // GetEventID extracts the event ID from a Matrix event
-func GetEventID(event map[string]any) (string, bool) {
-	eventID, ok := event["event_id"].(string)
-	return eventID, ok
+func GetEventID(event Event) string {
+	return event.EventID
 }
 
 // GetRoomID extracts the room ID from a Matrix event
-func GetRoomID(event map[string]any) (string, bool) {
-	roomID, ok := event["room_id"].(string)
-	return roomID, ok
+func GetRoomID(event Event) string {
+	return event.RoomID
 }

--- a/testcontainers/matrix/utils.go
+++ b/testcontainers/matrix/utils.go
@@ -2,10 +2,10 @@ package matrix
 
 // FindEventByPostID finds a Matrix event by its Mattermost post ID
 func FindEventByPostID(events []Event, postID string) *Event {
-	for _, event := range events {
+	for i, event := range events {
 		if mattermostPostID, exists := event.Content["mattermost_post_id"].(string); exists {
 			if mattermostPostID == postID {
-				return &event
+				return &events[i]
 			}
 		}
 	}
@@ -14,26 +14,29 @@ func FindEventByPostID(events []Event, postID string) *Event {
 
 // FindLatestMessageEvent finds the most recent m.room.message event
 func FindLatestMessageEvent(events []Event) *Event {
-	var latestEvent *Event
+	var latestEventIndex = -1
 	var latestTimestamp int64
 
-	for _, event := range events {
+	for i, event := range events {
 		if event.Type == "m.room.message" {
 			if event.Timestamp > latestTimestamp {
 				latestTimestamp = event.Timestamp
-				latestEvent = &event
+				latestEventIndex = i
 			}
 		}
 	}
 
-	return latestEvent
+	if latestEventIndex >= 0 {
+		return &events[latestEventIndex]
+	}
+	return nil
 }
 
 // FindEventByType finds the first event of a specific type
 func FindEventByType(events []Event, eventType string) *Event {
-	for _, event := range events {
+	for i, event := range events {
 		if event.Type == eventType {
-			return &event
+			return &events[i]
 		}
 	}
 	return nil
@@ -51,8 +54,12 @@ func FindEventsByType(events []Event, eventType string) []Event {
 }
 
 // GetEventContent extracts content from a Matrix event
-func GetEventContent(event Event) map[string]any {
-	return event.Content
+// Returns the content map and a boolean indicating if content exists
+func GetEventContent(event Event) (map[string]any, bool) {
+	if event.Content != nil {
+		return event.Content, true
+	}
+	return nil, false
 }
 
 // GetEventSender extracts the sender from a Matrix event

--- a/testcontainers/matrix/validation.go
+++ b/testcontainers/matrix/validation.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// MatrixEventValidation provides helpers for validating Matrix events in tests
+// EventValidation provides helpers for validating Matrix events in tests
 //
-//nolint:revive // MatrixEventValidation is intentionally named to be descriptive in test context
-type MatrixEventValidation struct {
+//nolint:revive // EventValidation is intentionally named to be descriptive in test context
+type EventValidation struct {
 	t            *testing.T
 	serverDomain string
 	remoteID     string
 }
 
-// NewMatrixEventValidation creates a new validation helper
-func NewMatrixEventValidation(t *testing.T, serverDomain, remoteID string) *MatrixEventValidation {
-	return &MatrixEventValidation{
+// NewEventValidation creates a new validation helper
+func NewEventValidation(t *testing.T, serverDomain, remoteID string) *EventValidation {
+	return &EventValidation{
 		t:            t,
 		serverDomain: serverDomain,
 		remoteID:     remoteID,
@@ -26,38 +26,34 @@ func NewMatrixEventValidation(t *testing.T, serverDomain, remoteID string) *Matr
 }
 
 // ValidateMessageEvent validates a basic Matrix message event structure
-func (v *MatrixEventValidation) ValidateMessageEvent(event map[string]any, originalPost any) {
+func (v *EventValidation) ValidateMessageEvent(event Event, originalPost any) {
 	// Verify basic event structure
-	assert.Equal(v.t, "m.room.message", event["type"], "Event should be a message")
-
-	content, ok := event["content"].(map[string]any)
-	require.True(v.t, ok, "Event should have content")
+	assert.Equal(v.t, "m.room.message", event.Type, "Event should be a message")
+	assert.NotNil(v.t, event.Content, "Event should have content")
 
 	// Verify message content
-	assert.Equal(v.t, "m.text", content["msgtype"], "Should be text message")
-	assert.NotEmpty(v.t, content["body"], "Should have message body")
+	assert.Equal(v.t, "m.text", event.Content["msgtype"], "Should be text message")
+	assert.NotEmpty(v.t, event.Content["body"], "Should have message body")
 
 	// Verify Mattermost metadata if provided
 	if originalPost != nil {
 		if post, ok := originalPost.(interface{ GetId() string }); ok {
-			assert.Equal(v.t, post.GetId(), content["mattermost_post_id"], "Should have correct post ID")
+			assert.Equal(v.t, post.GetId(), event.Content["mattermost_post_id"], "Should have correct post ID")
 		}
 	}
 
 	if v.remoteID != "" {
-		assert.Equal(v.t, v.remoteID, content["mattermost_remote_id"], "Should have correct remote ID")
+		assert.Equal(v.t, v.remoteID, event.Content["mattermost_remote_id"], "Should have correct remote ID")
 	}
 }
 
 // ValidateMessageWithMentions validates a Matrix message with mentions
-func (v *MatrixEventValidation) ValidateMessageWithMentions(event map[string]any, originalPost any, expectedMentionCount int) {
+func (v *EventValidation) ValidateMessageWithMentions(event Event, originalPost any, expectedMentionCount int) {
 	// First validate basic message structure
 	v.ValidateMessageEvent(event, originalPost)
 
-	content := event["content"].(map[string]any)
-
 	// Verify mention structure exists
-	mentions, hasMentions := content["m.mentions"].(map[string]any)
+	mentions, hasMentions := event.Content["m.mentions"].(map[string]any)
 	require.True(v.t, hasMentions, "Message with mentions should have m.mentions field")
 
 	userIDs, hasUserIDs := mentions["user_ids"].([]any)
@@ -65,19 +61,17 @@ func (v *MatrixEventValidation) ValidateMessageWithMentions(event map[string]any
 	assert.Len(v.t, userIDs, expectedMentionCount, "Should have expected number of mentions")
 
 	// Verify HTML formatting is present for mentions
-	_, hasHTML := content["formatted_body"]
+	_, hasHTML := event.Content["formatted_body"]
 	assert.True(v.t, hasHTML, "Message with mentions should have HTML formatted body")
-	assert.Equal(v.t, "org.matrix.custom.html", content["format"], "Should specify HTML format")
+	assert.Equal(v.t, "org.matrix.custom.html", event.Content["format"], "Should specify HTML format")
 }
 
 // ValidateThreadedMessage validates a threaded Matrix message
-func (v *MatrixEventValidation) ValidateThreadedMessage(event map[string]any, originalPost any, parentEventID string) {
+func (v *EventValidation) ValidateThreadedMessage(event Event, originalPost any, parentEventID string) {
 	v.ValidateMessageEvent(event, originalPost)
 
-	content := event["content"].(map[string]any)
-
 	// Verify threading relation
-	relatesTo, hasRelation := content["m.relates_to"].(map[string]any)
+	relatesTo, hasRelation := event.Content["m.relates_to"].(map[string]any)
 	require.True(v.t, hasRelation, "Threaded message should have m.relates_to")
 
 	assert.Equal(v.t, "m.thread", relatesTo["rel_type"], "Should use thread relation type")
@@ -85,15 +79,13 @@ func (v *MatrixEventValidation) ValidateThreadedMessage(event map[string]any, or
 }
 
 // ValidateFileMessage validates a Matrix file message event
-func (v *MatrixEventValidation) ValidateFileMessage(event map[string]any, expectedFilename string, expectedMimeType string) {
+func (v *EventValidation) ValidateFileMessage(event Event, expectedFilename string, expectedMimeType string) {
 	// Verify basic event structure
-	assert.Equal(v.t, "m.room.message", event["type"], "Event should be a message")
-
-	content, ok := event["content"].(map[string]any)
-	require.True(v.t, ok, "Event should have content")
+	assert.Equal(v.t, "m.room.message", event.Type, "Event should be a message")
+	assert.NotNil(v.t, event.Content, "Event should have content")
 
 	// Verify file message type based on MIME type
-	msgType := content["msgtype"].(string)
+	msgType := event.Content["msgtype"].(string)
 	//nolint:staticcheck // Switch statement is more readable than tagged switch for this use case
 	switch {
 	case expectedMimeType == "image/png" || expectedMimeType == "image/jpeg":
@@ -107,23 +99,21 @@ func (v *MatrixEventValidation) ValidateFileMessage(event map[string]any, expect
 	}
 
 	// Verify file metadata
-	assert.Equal(v.t, expectedFilename, content["body"], "Should have correct filename")
+	assert.Equal(v.t, expectedFilename, event.Content["body"], "Should have correct filename")
 
-	fileInfo, hasFileInfo := content["info"].(map[string]any)
+	fileInfo, hasFileInfo := event.Content["info"].(map[string]any)
 	require.True(v.t, hasFileInfo, "File message should have info")
 	assert.Equal(v.t, expectedMimeType, fileInfo["mimetype"], "Should have correct MIME type")
 }
 
 // ValidateReactionEvent validates a Matrix reaction event
-func (v *MatrixEventValidation) ValidateReactionEvent(event map[string]any, targetEventID string, expectedEmoji string) {
+func (v *EventValidation) ValidateReactionEvent(event Event, targetEventID string, expectedEmoji string) {
 	// Verify basic event structure
-	assert.Equal(v.t, "m.reaction", event["type"], "Event should be a reaction")
-
-	content, ok := event["content"].(map[string]any)
-	require.True(v.t, ok, "Event should have content")
+	assert.Equal(v.t, "m.reaction", event.Type, "Event should be a reaction")
+	assert.NotNil(v.t, event.Content, "Event should have content")
 
 	// Verify reaction relation
-	relatesTo, hasRelation := content["m.relates_to"].(map[string]any)
+	relatesTo, hasRelation := event.Content["m.relates_to"].(map[string]any)
 	require.True(v.t, hasRelation, "Reaction should have m.relates_to")
 
 	assert.Equal(v.t, "m.annotation", relatesTo["rel_type"], "Should use annotation relation type")
@@ -132,22 +122,20 @@ func (v *MatrixEventValidation) ValidateReactionEvent(event map[string]any, targ
 }
 
 // ValidateEditEvent validates a Matrix message edit event
-func (v *MatrixEventValidation) ValidateEditEvent(event map[string]any, originalEventID string, expectedNewContent string) {
+func (v *EventValidation) ValidateEditEvent(event Event, originalEventID string, expectedNewContent string) {
 	// Verify basic event structure
-	assert.Equal(v.t, "m.room.message", event["type"], "Event should be a message")
-
-	content, ok := event["content"].(map[string]any)
-	require.True(v.t, ok, "Event should have content")
+	assert.Equal(v.t, "m.room.message", event.Type, "Event should be a message")
+	assert.NotNil(v.t, event.Content, "Event should have content")
 
 	// Verify edit relation
-	relatesTo, hasRelation := content["m.relates_to"].(map[string]any)
+	relatesTo, hasRelation := event.Content["m.relates_to"].(map[string]any)
 	require.True(v.t, hasRelation, "Edit should have m.relates_to")
 
 	assert.Equal(v.t, "m.replace", relatesTo["rel_type"], "Should use replace relation type")
 	assert.Equal(v.t, originalEventID, relatesTo["event_id"], "Should reference original event")
 
 	// Verify new content
-	newContent, hasNewContent := content["m.new_content"].(map[string]any)
+	newContent, hasNewContent := event.Content["m.new_content"].(map[string]any)
 	require.True(v.t, hasNewContent, "Edit should have m.new_content")
 	assert.Equal(v.t, expectedNewContent, newContent["body"], "Should have correct new content")
 }


### PR DESCRIPTION
#### Summary
Ensures room membership is correctly populated in Matrix when room is created and when members are added to the corresponding Mattermost channel.  

Members are already added to Mattermost channels when invited to Matrix rooms by other Matrix users.

Adds unit tests for the new methods.

Adds rate limiting to matrix client.

#### Ticket Link
NONE