### PR TITLE
Add inbound Matrix routing by hs_token (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,69 +100,9 @@ make generate-emoji
 
 ## Local Development with Matrix Synapse
 
-For local development and testing, you can run a Matrix Synapse server using Docker Compose.
-
-### Prerequisites
-
-1. Install and configure the Mattermost Matrix Bridge plugin first
-    - **Matrix Server URL**: `http://localhost:8888`
-2. Generate the bridge registration file through the plugin configuration
-3. Copy the generated registration file to `docker/mattermost-bridge-registration.yaml`
-
-### Starting the Matrix Synapse Server
-
-1. Start the services:
-
-    ```bash
-    docker-compose up -d
-    ```
-
-2. Create an admin user:
-
-    ```bash
-    docker exec -it mattermost-plugin-matrix-bridge-synapse-1 register_new_matrix_user -c /data/homeserver.yaml -u admin -p admin123 -a http://localhost:8008
-    ```
-
-3. The Matrix server will be available at `http://localhost:8888`
-
-### Accessing the Web Chat Interface (Element)
-
-Synapse is only a homeserver and has no built-in chat UI. The Docker Compose stack
-includes an [Element Web](https://element.io/) client for testing:
-
-1. Start the Element service (included in `docker-compose up -d`, or start it alone):
-
-    ```bash
-    docker-compose up -d element
-    ```
-
-2. Open `http://localhost:8880` in your browser.
-
-3. It is pre-configured to use the local homeserver (`http://localhost:8888`), so you
-   can register or sign in with a test user directly. Registration is enabled for
-   development, so you can create new users from the login screen.
-
-Element's configuration lives in `docker/element-config.json`.
-
-### Configuration Notes
-
-- The Synapse server is configured to use PostgreSQL as the database
-- Registration is enabled for development purposes
-- App service configuration is loaded from `docker/mattermost-bridge-registration.yaml`
-- Room list publication is restricted to the bridge user only
-- An Element Web client is available at `http://localhost:8880` for manual testing
-
-### Stopping the Services
-
-```bash
-docker-compose down
-```
-
-To completely reset (remove all data):
-
-```bash
-docker-compose down -v
-```
+For local development and testing, you can run one or two Matrix Synapse servers using
+Docker Compose. See **[docs/local-development.md](docs/local-development.md)** for the full
+guide, including multi-server testing and connecting channels to a second homeserver.
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,62 @@ services:
         volumes:
             - postgres-data:/var/lib/postgresql/data
 
+    # --- Second Matrix homeserver, for manual multi-server testing ---
+    # server_name "synapse2.localhost" resolves to 127.0.0.1 (*.localhost) and is
+    # a distinct hostname from the first server, so the plugin derives a distinct
+    # serverID for it. Inject it into the plugin with `/matrix server add`.
+    synapse2-init:
+        image: alpine:latest
+        command: |
+            sh -c "
+              chown -R 991:991 /data
+              chmod -R 755 /data
+            "
+        volumes:
+            - synapse2-data:/data
+
+    synapse2:
+        image: matrixdotorg/synapse:latest
+        restart: unless-stopped
+        environment:
+            - SYNAPSE_SERVER_NAME=synapse2.localhost
+            - SYNAPSE_REPORT_STATS=no
+            - UID=991
+            - GID=991
+        volumes:
+            - synapse2-data:/data
+            - ./docker/synapse2_config.yaml:/data/homeserver.yaml:ro
+            - ./docker/mattermost-bridge-registration2.yaml:/data/mattermost-bridge-registration.yaml:ro
+        ports:
+            - "8889:8008"
+            - "8449:8448"
+        depends_on:
+            - synapse2-init
+            - postgres2
+
+    element2:
+        image: vectorim/element-web:latest
+        restart: unless-stopped
+        ports:
+            - "8881:80"
+        volumes:
+            - ./docker/element2-config.json:/app/config.json:ro
+        depends_on:
+            - synapse2
+
+    postgres2:
+        image: postgres:14
+        restart: unless-stopped
+        environment:
+            - POSTGRES_DB=synapse
+            - POSTGRES_USER=synapse
+            - POSTGRES_PASSWORD=synapse
+            - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
+        volumes:
+            - postgres2-data:/var/lib/postgresql/data
+
 volumes:
     synapse-data:
     postgres-data:
+    synapse2-data:
+    postgres2-data:

--- a/docker/element2-config.json
+++ b/docker/element2-config.json
@@ -1,0 +1,13 @@
+{
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "http://synapse2.localhost:8889",
+            "server_name": "synapse2.localhost"
+        }
+    },
+    "disable_custom_urls": false,
+    "disable_guests": false,
+    "brand": "Element (dev, synapse2)",
+    "default_country_code": "US",
+    "show_labs_settings": true
+}

--- a/docker/mattermost-bridge-registration2.yaml
+++ b/docker/mattermost-bridge-registration2.yaml
@@ -1,0 +1,25 @@
+id: "mattermost-bridge"
+url: "https://pasokon-2.tail893a6.ts.net/plugins/com.mattermost.plugin-matrix-bridge"
+# Each homeserver must present a UNIQUE hs_token: the plugin routes inbound
+# Application Service traffic to the right server by matching this token.
+as_token: "syn2_5Kd9WmXpQ2rLtVnB7cYhFgJ4sZaEuNi"
+hs_token: "syn2_Tb3Rk8VpMxWq6NcYdL2fHgJ7sUaZ0eYi"
+sender_localpart: "_mattermost_bridge"
+namespaces:
+  users:
+    - exclusive: true
+      regex: "@_mattermost_.*:synapse2.localhost"
+  aliases:
+    - exclusive: true
+      regex: "#_mattermost_.*:synapse2.localhost"
+    - exclusive: false
+      regex: "#mattermost-bridge-.*:synapse2.localhost"
+  rooms:
+    - exclusive: false
+      regex: "!.*:synapse2.localhost"
+rate_limited: false
+protocols: ["mattermost"]
+de.sorunome.msc2409.push_ephemeral: true
+permissions:
+  - "m.room.directory"
+  - "m.room.membership"

--- a/docker/synapse2_config.yaml
+++ b/docker/synapse2_config.yaml
@@ -1,0 +1,70 @@
+server_name: "synapse2.localhost"
+pid_file: /data/homeserver.pid
+public_baseurl: http://synapse2.localhost:8889/
+
+listeners:
+  - port: 8008
+    tls: false
+    type: http
+    x_forwarded: true
+    resources:
+      - names: [client, federation]
+        compress: false
+
+database:
+  name: psycopg2
+  args:
+    user: synapse
+    password: synapse
+    database: synapse
+    host: postgres2
+    port: 5432
+    cp_min: 5
+    cp_max: 10
+
+log:
+  version: 1
+  formatters:
+    precise:
+      format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: precise
+  loggers:
+    synapse:
+      level: INFO
+    synapse.access:
+      level: INFO
+  root:
+    level: INFO
+    handlers: [console]
+
+media_store_path: "/data/media_store"
+max_upload_size: 50M
+max_image_pixels: 32M
+
+registration_shared_secret: "development_secret_key_change_in_production"
+macaroon_secret_key: "development_macaroon_secret_change_in_production"
+form_secret: "development_form_secret_change_in_production"
+
+signing_key_path: "/data/signing.key"
+
+trusted_key_servers:
+  - server_name: "matrix.org"
+
+enable_registration: true
+enable_registration_without_verification: true
+
+suppress_key_server_warning: true
+
+room_list_publication_rules:
+  - user_id: "@_mattermost_bridge:synapse2.localhost"
+    action: allow
+  - user_id: "*"
+    action: deny
+
+app_service_config_files:
+  - /data/mattermost-bridge-registration.yaml
+
+report_stats: false

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,152 @@
+# Local Development with Matrix Synapse
+
+For local development and testing, you can run a Matrix Synapse server using Docker Compose.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Starting the Matrix Synapse Server](#starting-the-matrix-synapse-server)
+- [Accessing the Web Chat Interface (Element)](#accessing-the-web-chat-interface-element)
+- [Configuration Notes](#configuration-notes)
+- [Multi-Server Testing (two homeservers)](#multi-server-testing-two-homeservers)
+    - [Connecting a channel to a room on the second server](#connecting-a-channel-to-a-room-on-the-second-server)
+- [Stopping the Services](#stopping-the-services)
+
+## Prerequisites
+
+1. Install and configure the Mattermost Matrix Bridge plugin first
+    - **Matrix Server URL**: `http://localhost:8888`
+2. Generate the bridge registration file through the plugin configuration
+3. Copy the generated registration file to `docker/mattermost-bridge-registration.yaml`
+
+## Starting the Matrix Synapse Server
+
+1. Start the services:
+
+    ```bash
+    docker-compose up -d
+    ```
+
+2. Create an admin user:
+
+    ```bash
+    docker exec -it mattermost-plugin-matrix-bridge-synapse-1 register_new_matrix_user -c /data/homeserver.yaml -u admin -p admin123 -a http://localhost:8008
+    ```
+
+3. The Matrix server will be available at `http://localhost:8888`
+
+## Accessing the Web Chat Interface (Element)
+
+Synapse is only a homeserver and has no built-in chat UI. The Docker Compose stack
+includes an [Element Web](https://element.io/) client for testing:
+
+1. Start the Element service (included in `docker-compose up -d`, or start it alone):
+
+    ```bash
+    docker-compose up -d element
+    ```
+
+2. Open `http://localhost:8880` in your browser.
+
+3. It is pre-configured to use the local homeserver (`http://localhost:8888`), so you
+   can register or sign in with a test user directly. Registration is enabled for
+   development, so you can create new users from the login screen.
+
+Element's configuration lives in `docker/element-config.json`.
+
+## Configuration Notes
+
+- The Synapse server is configured to use PostgreSQL as the database
+- Registration is enabled for development purposes
+- App service configuration is loaded from `docker/mattermost-bridge-registration.yaml`
+- Room list publication is restricted to the bridge user only
+- An Element Web client is available at `http://localhost:8880` for manual testing
+
+## Multi-Server Testing (two homeservers)
+
+The Docker Compose stack includes a **second, independent homeserver** so you can
+exercise multi-server bridging locally. It runs alongside the first:
+
+|                   | Server 1                                     | Server 2                                      |
+| ----------------- | -------------------------------------------- | --------------------------------------------- |
+| Server name       | `localhost`                                  | `synapse2.localhost`                          |
+| Matrix API (host) | `http://localhost:8888`                      | `http://synapse2.localhost:8889`              |
+| Element client    | `http://localhost:8880`                      | `http://localhost:8881`                       |
+| Registration file | `docker/mattermost-bridge-registration.yaml` | `docker/mattermost-bridge-registration2.yaml` |
+
+`synapse2.localhost` resolves to `127.0.0.1` automatically (the `.localhost` TLD),
+so no `/etc/hosts` changes are needed. The two servers must use **distinct
+hostnames** — the plugin derives each server's ID from its URL hostname, and both
+homeservers carry **distinct `hs_token`s** so inbound traffic routes to the right one.
+
+Bring everything up and create an admin user on the second server:
+
+```bash
+docker-compose up -d
+docker exec -it mattermost-plugin-matrix-bridge-synapse2-1 register_new_matrix_user -c /data/homeserver.yaml -u admin -p admin123 -a http://localhost:8008
+```
+
+Configure **Server 1** as usual through the System Console (Matrix Server URL
+`http://localhost:8888`). The System Console UI can only manage a single server, so
+register **Server 2** with the admin-only slash command (the tokens come from
+`docker/mattermost-bridge-registration2.yaml`):
+
+```
+/matrix server add http://synapse2.localhost:8889 synapse2.localhost syn2_5Kd9WmXpQ2rLtVnB7cYhFgJ4sZaEuNi syn2_Tb3Rk8VpMxWq6NcYdL2fHgJ7sUaZ0eYi matrix2
+```
+
+Other server-management commands:
+
+- `/matrix server list` — show all registered servers and their IDs
+- `/matrix server remove <server_id>` — remove an injected server
+
+### Connecting a channel to a room on the second server
+
+The regular `/matrix map` and `/matrix create` commands always target the primary
+server (the one configured in the System Console). To bridge a channel to a room on
+the **second** server, use the server-scoped map command:
+
+1. Create (or find) a room on server 2 — for example, sign in at
+   `http://localhost:8881` (Element for server 2) and create a room.
+2. Find the second server's ID with `/matrix server list`.
+3. In the Mattermost channel you want to bridge, run:
+
+    ```
+    /matrix server map <server_id> <room_alias_or_id>
+    ```
+
+    for example:
+
+    ```
+    /matrix server map yjfnsajexkwmmmphkd4ceyte9a #room:synapse2.localhost
+    ```
+
+This resolves the room, joins the bridge bot on server 2, and stores the mapping
+under that server's namespace (preserving any mapping the channel already has to the
+primary server). Send a message in the Matrix room and it appears in the Mattermost
+channel.
+
+> **Inbound only for now:** messages **from** server 2 sync **into** Mattermost. The
+> reverse direction (Mattermost → a non-primary server) is not yet wired — outbound
+> multi-server routing lands in a later phase — so posting in the Mattermost channel
+> will not (yet) reach server 2's room.
+
+Notes:
+
+- These commands require System Administrator privileges.
+- Injected servers persist in the plugin's KV store and survive restarts and plugin
+  reconfiguration. The single server configured in the System Console is always the
+  "primary"; removing it via the command is not permanent (it is re-derived from the
+  configuration), whereas injected servers can be removed permanently.
+
+## Stopping the Services
+
+```bash
+docker-compose down
+```
+
+To completely reset (remove all data):
+
+```bash
+docker-compose down -v
+```

--- a/server/api.go
+++ b/server/api.go
@@ -2,12 +2,30 @@
 package main
 
 import (
+	"context"
 	"crypto/subtle"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost/server/public/plugin"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/store/kvstore"
 )
+
+// contextKey is an unexported type for keys stored in a request context, avoiding
+// collisions with keys defined in other packages.
+type contextKey string
+
+// matrixServerIDContextKey carries the serverID resolved by the Matrix auth
+// middleware (from the presented hs_token) to the downstream webhook handler.
+const matrixServerIDContextKey contextKey = "matrix_server_id"
+
+// serverIDFromContext returns the serverID resolved by MatrixAuthorizationRequired
+// for the current request. The bool is false if no serverID was injected.
+func serverIDFromContext(ctx context.Context) (string, bool) {
+	serverID, ok := ctx.Value(matrixServerIDContextKey).(string)
+	return serverID, ok
+}
 
 // ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
 // The root URL is currently <siteUrl>/plugins/com.mattermost.plugin-starter-template/api/v1/. Replace com.mattermost.plugin-starter-template with the plugin ID.
@@ -40,35 +58,66 @@ func (p *Plugin) MattermostAuthorizationRequired(next http.Handler) http.Handler
 	})
 }
 
-// MatrixAuthorizationRequired is a middleware that requires valid Matrix hs_token authentication.
+// MatrixAuthorizationRequired is a middleware that requires valid Matrix hs_token
+// authentication. Each managed homeserver has its own hs_token, so the presented
+// bearer token is matched against every server's HSToken to resolve which server
+// the transaction originated from. The resolved serverID is injected into the
+// request context for the downstream handler.
 func (p *Plugin) MatrixAuthorizationRequired(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		config := p.getConfiguration()
-
-		// Check if sync is enabled
-		if !config.EnableSync {
+		// Master switch: reject all inbound traffic when sync is globally disabled.
+		if !p.getConfiguration().EnableSync {
 			p.logger.LogDebug("Matrix webhook received but sync is disabled")
 			http.Error(w, "Sync disabled", http.StatusServiceUnavailable)
 			return
 		}
 
-		// Verify hs_token in Authorization header
-		authHeader := r.Header.Get("Authorization")
-		expectedToken := "Bearer " + config.MatrixHSToken
-
-		if config.MatrixHSToken == "" {
-			p.logger.LogWarn("Matrix webhook received but hs_token not configured")
+		servers, err := p.getServers()
+		if err != nil {
+			p.logger.LogError("Matrix webhook received but server registry could not be read", "error", err)
+			http.Error(w, "Matrix not configured", http.StatusServiceUnavailable)
+			return
+		}
+		if len(servers) == 0 {
+			p.logger.LogWarn("Matrix webhook received but no Matrix server is configured")
 			http.Error(w, "Matrix not configured", http.StatusServiceUnavailable)
 			return
 		}
 
-		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(expectedToken)) != 1 {
-			p.logger.LogWarn("Matrix webhook authentication failed - bearer token mismatch")
+		// Match the presented token against every server's hs_token. Scan the full
+		// list (no early return) so the work is independent of which server matches;
+		// the registry holds only a handful of servers so this stays bounded.
+		authHeader := r.Header.Get("Authorization")
+		matched := kvstore.ServerConfig{}
+		found := false
+		for _, server := range servers {
+			if server.HSToken == "" {
+				// A server without an hs_token can never authenticate a webhook;
+				// skip it so an empty presented token never matches an empty config.
+				continue
+			}
+			expectedToken := "Bearer " + server.HSToken
+			if subtle.ConstantTimeCompare([]byte(authHeader), []byte(expectedToken)) == 1 {
+				matched = server
+				found = true
+			}
+		}
+
+		if !found {
+			p.logger.LogWarn("Matrix webhook authentication failed - bearer token did not match any configured server")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		next.ServeHTTP(w, r)
+		// Per-server switch: a matched but disabled server must not accept traffic.
+		if !matched.Enabled {
+			p.logger.LogDebug("Matrix webhook received for a disabled server", "server_id", matched.ServerID)
+			http.Error(w, "Sync disabled", http.StatusServiceUnavailable)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), matrixServerIDContextKey, matched.ServerID)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/server/api_test.go
+++ b/server/api_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/store/kvstore"
+)
+
+// newAuthTestPlugin builds a plugin with an in-memory KV store, a global
+// EnableSync flag, and the given server registry entries.
+func newAuthTestPlugin(t *testing.T, enableSync bool, servers []kvstore.ServerConfig) *Plugin {
+	t.Helper()
+	plugin := &Plugin{}
+	plugin.logger = &testLogger{t: t}
+	plugin.configuration = &configuration{EnableSync: enableSync}
+	plugin.kvstore = NewMemoryKVStore()
+	data, err := json.Marshal(servers)
+	require.NoError(t, err)
+	require.NoError(t, plugin.kvstore.Set(kvstore.KeyServersConfig, data))
+	return plugin
+}
+
+// serveAuth runs a request with the given bearer token through
+// MatrixAuthorizationRequired, returning the status code and the serverID the
+// inner handler observed in the request context (empty when the handler did not
+// run).
+func serveAuth(p *Plugin, bearer string) (status int, resolvedServerID string, handlerRan bool) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerRan = true
+		resolvedServerID, _ = serverIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/_matrix/app/v1/transactions/txn1", nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	p.MatrixAuthorizationRequired(inner).ServeHTTP(rec, req)
+	return rec.Code, resolvedServerID, handlerRan
+}
+
+func TestMatrixAuthorizationRequired(t *testing.T) {
+	twoServers := []kvstore.ServerConfig{
+		{ServerID: "serverAserverAserverAserv01", ServerURL: "https://a.example.com", HSToken: "hs_token_a", Enabled: true},
+		{ServerID: "serverBserverBserverBserv02", ServerURL: "https://b.example.com", HSToken: "hs_token_b", Enabled: true},
+	}
+
+	t.Run("token A resolves server A", func(t *testing.T) {
+		p := newAuthTestPlugin(t, true, twoServers)
+		status, serverID, ran := serveAuth(p, "hs_token_a")
+		assert.Equal(t, http.StatusOK, status)
+		assert.True(t, ran)
+		assert.Equal(t, "serverAserverAserverAserv01", serverID)
+	})
+
+	t.Run("token B resolves server B", func(t *testing.T) {
+		p := newAuthTestPlugin(t, true, twoServers)
+		status, serverID, ran := serveAuth(p, "hs_token_b")
+		assert.Equal(t, http.StatusOK, status)
+		assert.True(t, ran)
+		assert.Equal(t, "serverBserverBserverBserv02", serverID)
+	})
+
+	t.Run("unknown token is unauthorized and handler does not run", func(t *testing.T) {
+		p := newAuthTestPlugin(t, true, twoServers)
+		status, _, ran := serveAuth(p, "not_a_real_token")
+		assert.Equal(t, http.StatusUnauthorized, status)
+		assert.False(t, ran)
+	})
+
+	t.Run("global sync disabled returns 503", func(t *testing.T) {
+		p := newAuthTestPlugin(t, false, twoServers)
+		status, _, ran := serveAuth(p, "hs_token_a")
+		assert.Equal(t, http.StatusServiceUnavailable, status)
+		assert.False(t, ran)
+	})
+
+	t.Run("matched but disabled server returns 503", func(t *testing.T) {
+		servers := []kvstore.ServerConfig{
+			{ServerID: "serverAserverAserverAserv01", ServerURL: "https://a.example.com", HSToken: "hs_token_a", Enabled: false},
+		}
+		p := newAuthTestPlugin(t, true, servers)
+		status, _, ran := serveAuth(p, "hs_token_a")
+		assert.Equal(t, http.StatusServiceUnavailable, status)
+		assert.False(t, ran)
+	})
+
+	t.Run("empty presented token never matches an empty hs_token", func(t *testing.T) {
+		servers := []kvstore.ServerConfig{
+			{ServerID: "serverAserverAserverAserv01", ServerURL: "https://a.example.com", HSToken: "", Enabled: true},
+		}
+		p := newAuthTestPlugin(t, true, servers)
+		// No Authorization header at all.
+		status, _, ran := serveAuth(p, "")
+		assert.Equal(t, http.StatusUnauthorized, status)
+		assert.False(t, ran)
+	})
+
+	t.Run("no servers configured returns 503", func(t *testing.T) {
+		p := newAuthTestPlugin(t, true, nil)
+		status, _, ran := serveAuth(p, "hs_token_a")
+		assert.Equal(t, http.StatusServiceUnavailable, status)
+		assert.False(t, ran)
+	})
+}

--- a/server/bridge_utils.go
+++ b/server/bridge_utils.go
@@ -115,21 +115,18 @@ func (s *BridgeUtils) setChannelRoomMapping(channelID, matrixRoomIdentifier stri
 
 	// Store forward mapping: channel_mapping_<channelID> -> [{serverID, room_id}].
 	// Upsert only this server's entry so a channel bridged to multiple homeservers
-	// keeps the others' mappings intact.
-	existingData, err := s.kvstore.Get(kvstore.BuildChannelMappingKey(channelID))
-	if err != nil {
-		return errors.Wrap(err, "failed to read existing channel room mapping")
-	}
-	mappings, err := kvstore.ParseChannelServerMappings(existingData)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse existing channel room mapping")
-	}
-	mappings = kvstore.UpsertChannelServerMapping(mappings, s.serverID, roomID)
-	mappingValue, err := kvstore.MarshalChannelServerMappings(mappings)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal channel room mapping")
-	}
-	err = s.kvstore.Set(kvstore.BuildChannelMappingKey(channelID), mappingValue)
+	// keeps the others' mappings intact. Use compare-and-set with retries because
+	// the value is shared across servers: two inbound events racing on the same
+	// channel key would otherwise read-modify-write over each other and drop an
+	// entry.
+	err = s.kvstore.SetAtomicWithRetries(kvstore.BuildChannelMappingKey(channelID), func(oldValue []byte) ([]byte, error) {
+		mappings, err := kvstore.ParseChannelServerMappings(oldValue)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse existing channel room mapping")
+		}
+		mappings = kvstore.UpsertChannelServerMapping(mappings, s.serverID, roomID)
+		return kvstore.MarshalChannelServerMappings(mappings)
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to store channel room mapping")
 	}
@@ -185,6 +182,31 @@ func (s *BridgeUtils) matrixUsernamePrefix() string {
 	}
 	// No registry yet (before the first reconcile) or no entry for this server.
 	return DefaultMatrixUsernamePrefix
+}
+
+// serverDomain returns the property-key-sanitized domain of this bridge's Matrix
+// server, resolved from the managed server registry (the source of truth for
+// per-server settings). It is used to build the per-server post property key
+// "matrix_event_id_<domain>". When no registry entry exists for this server (e.g.
+// before the first reconcile), it falls back to the flat configuration, which
+// yields the same value in the single-server case. The registry is read live,
+// mirroring matrixUsernamePrefix.
+func (s *BridgeUtils) serverDomain() string {
+	data, err := s.kvstore.Get(kvstore.KeyServersConfig)
+	if err != nil {
+		s.logger.LogError("Failed to read server registry for server domain; using config fallback", "server_id", s.serverID, "error", err)
+		return extractServerDomain(s.logger, s.getConfiguration().MatrixServerURL)
+	}
+	servers, err := kvstore.ParseServersConfig(data)
+	if err != nil {
+		s.logger.LogError("Corrupt server registry; using config fallback for server domain", "server_id", s.serverID, "error", err)
+		return extractServerDomain(s.logger, s.getConfiguration().MatrixServerURL)
+	}
+	if server, ok := kvstore.ServerConfigForID(servers, s.serverID); ok && server.ServerURL != "" {
+		return extractServerDomain(s.logger, server.ServerURL)
+	}
+	// No registry yet (before the first reconcile) or no entry for this server.
+	return extractServerDomain(s.logger, s.getConfiguration().MatrixServerURL)
 }
 
 func (s *BridgeUtils) extractMattermostMetadata(event MatrixEvent) (postID string, remoteID string) {

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -59,6 +59,14 @@ type PluginAccessor interface {
 	// Migration access
 	RunKVStoreMigrations() error
 	RunKVStoreMigrationsWithResults() (*MigrationResult, error)
+
+	// Managed server registry access (local multi-server testing). The System
+	// Console UI cannot yet manage more than one server, so these back the
+	// `/matrix server` command that injects additional servers directly.
+	GetManagedServers() ([]kvstore.ServerConfig, error)
+	AddManagedServer(serverURL, serverName, asToken, hsToken, usernamePrefix string) (string, error)
+	RemoveManagedServer(serverID string) (bool, error)
+	GetMatrixClientForServer(serverID string) *matrix.Client
 }
 
 // sanitizeShareName creates a valid ShareName matching the regex: ^[a-z0-9]+([a-z\-\_0-9]+|(__)?)[a-z0-9]*$
@@ -209,6 +217,15 @@ const (
 	listCommandDesc    = "List all channel-to-room mappings"
 	statusCommandDesc  = "Show bridge status"
 	migrateCommandDesc = "Reset and re-run KV store migrations to fix missing room mappings"
+	serverCommandDesc  = "Manage additional Matrix servers (admin only, local multi-server testing)"
+
+	// server subcommand usage
+	serverCommandUsage = "Usage: /matrix server [list|add|remove|map]\n" +
+		"• `/matrix server list` - Show all registered Matrix servers\n" +
+		"• `/matrix server add <server_url> <server_name> <as_token> <hs_token> [username_prefix]` - Register/replace a Matrix server\n" +
+		"• `/matrix server remove <server_id>` - Remove a registered Matrix server\n" +
+		"• `/matrix server map <server_id> <room_alias|room_id>` - Map the current channel to a room on a specific server"
+	serverAdminOnlyError = "❌ This command requires System Administrator privileges."
 
 	// Map command usage and validation
 	mapCommandUsage     = "Usage: /matrix map [room_alias|room_id]\nExample: /matrix map #test-sync:synapse-mydomain.com"
@@ -285,6 +302,25 @@ func NewCommandHandler(plugin PluginAccessor) Command {
 	matrixData.AddCommand(model.NewAutocompleteData("list", "", listCommandDesc))
 	matrixData.AddCommand(model.NewAutocompleteData("status", "", statusCommandDesc))
 	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", migrateCommandDesc))
+
+	// Server management command (admin only) for local multi-server testing.
+	serverCmd := model.NewAutocompleteData("server", "[list|add|remove]", serverCommandDesc)
+	serverCmd.AddCommand(model.NewAutocompleteData("list", "", "List all registered Matrix servers"))
+	serverAddCmd := model.NewAutocompleteData("add", "<server_url> <server_name> <as_token> <hs_token> [username_prefix]", "Register or replace a Matrix server")
+	serverAddCmd.AddTextArgument("Matrix homeserver base URL", "<server_url>", "")
+	serverAddCmd.AddTextArgument("Matrix server name (domain in user IDs)", "<server_name>", "")
+	serverAddCmd.AddTextArgument("Application Service token", "<as_token>", "")
+	serverAddCmd.AddTextArgument("Homeserver token", "<hs_token>", "")
+	serverAddCmd.AddTextArgument("Optional username prefix", "[username_prefix]", "")
+	serverCmd.AddCommand(serverAddCmd)
+	serverRemoveCmd := model.NewAutocompleteData("remove", "<server_id>", "Remove a registered Matrix server")
+	serverRemoveCmd.AddTextArgument("Server ID (from /matrix server list)", "<server_id>", "")
+	serverCmd.AddCommand(serverRemoveCmd)
+	serverMapCmd := model.NewAutocompleteData("map", "<server_id> <room_alias|room_id>", "Map the current channel to a room on a specific server")
+	serverMapCmd.AddTextArgument("Server ID (from /matrix server list)", "<server_id>", "")
+	serverMapCmd.AddTextArgument("Matrix room alias or room ID", "<room_alias|room_id>", "")
+	serverCmd.AddCommand(serverMapCmd)
+	matrixData.AddCommand(serverCmd)
 
 	err := client.SlashCommand.Register(&model.Command{
 		Trigger:          matrixCommandTrigger,
@@ -882,11 +918,204 @@ func (c *Handler) executeMatrixCommand(args *model.CommandArgs) *model.CommandRe
 		}
 	case "migrate":
 		return c.executeMigrateCommand(args)
+	case "server":
+		return c.executeServerCommand(args, fields)
 	default:
 		return &model.CommandResponse{
 			ResponseType: model.CommandResponseTypeEphemeral,
 			Text:         unknownSubcommandError,
 		}
+	}
+}
+
+// executeServerCommand handles the admin-only `/matrix server` subcommand group,
+// which injects additional Matrix servers into the registry for local
+// multi-server testing (the System Console UI supports only one server today).
+func (c *Handler) executeServerCommand(args *model.CommandArgs, fields []string) *model.CommandResponse {
+	// Gate on System Administrator: this writes bridge routing config.
+	if !c.pluginAPI.HasPermissionTo(args.UserId, model.PermissionManageSystem) {
+		return ephemeral(serverAdminOnlyError)
+	}
+
+	if len(fields) < 3 {
+		return ephemeral(serverCommandUsage)
+	}
+
+	switch fields[2] {
+	case "list":
+		return c.executeServerListCommand()
+	case "add":
+		return c.executeServerAddCommand(fields)
+	case "remove":
+		return c.executeServerRemoveCommand(fields)
+	case "map":
+		return c.executeServerMapCommand(args, fields)
+	default:
+		return ephemeral(serverCommandUsage)
+	}
+}
+
+func (c *Handler) executeServerListCommand() *model.CommandResponse {
+	servers, err := c.plugin.GetManagedServers()
+	if err != nil {
+		c.client.Log.Error("Failed to read managed servers", "error", err)
+		return ephemeral("❌ Failed to read the server registry. Check plugin logs for details.")
+	}
+	if len(servers) == 0 {
+		return ephemeral("No Matrix servers are registered.")
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Registered Matrix servers (%d):**\n", len(servers))
+	for _, s := range servers {
+		enabled := "disabled"
+		if s.Enabled {
+			enabled = "enabled"
+		}
+		injected := ""
+		if s.Injected {
+			injected = " _(injected)_"
+		}
+		fmt.Fprintf(&b, "\n• **%s** (`%s`)%s\n", s.ServerName, s.ServerID, injected)
+		fmt.Fprintf(&b, "  - URL: `%s`\n", s.ServerURL)
+		fmt.Fprintf(&b, "  - Username prefix: `%s`\n", s.UsernamePrefix)
+		fmt.Fprintf(&b, "  - Status: %s\n", enabled)
+	}
+	return ephemeral(b.String())
+}
+
+func (c *Handler) executeServerAddCommand(fields []string) *model.CommandResponse {
+	// /matrix server add <server_url> <server_name> <as_token> <hs_token> [username_prefix]
+	if len(fields) < 7 {
+		return ephemeral(serverCommandUsage)
+	}
+	serverURL := fields[3]
+	serverName := fields[4]
+	asToken := fields[5]
+	hsToken := fields[6]
+	usernamePrefix := ""
+	if len(fields) >= 8 {
+		usernamePrefix = fields[7]
+	}
+
+	serverID, err := c.plugin.AddManagedServer(serverURL, serverName, asToken, hsToken, usernamePrefix)
+	if err != nil {
+		c.client.Log.Error("Failed to add managed server", "error", err, "server_url", serverURL)
+		return ephemeral(fmt.Sprintf("❌ Failed to add server: %s", err.Error()))
+	}
+
+	c.client.Log.Info("Added managed Matrix server", "server_id", serverID, "server_url", serverURL, "server_name", serverName)
+	return ephemeral(fmt.Sprintf("✅ **Server registered**\n\n**Name:** %s\n**Server ID:** `%s`\n**URL:** `%s`\n\nInbound events authenticated with this server's `hs_token` now route to it. Use `/matrix server list` to review.", serverName, serverID, serverURL))
+}
+
+func (c *Handler) executeServerRemoveCommand(fields []string) *model.CommandResponse {
+	// /matrix server remove <server_id>
+	if len(fields) < 4 {
+		return ephemeral(serverCommandUsage)
+	}
+	serverID := fields[3]
+
+	removed, err := c.plugin.RemoveManagedServer(serverID)
+	if err != nil {
+		c.client.Log.Error("Failed to remove managed server", "error", err, "server_id", serverID)
+		return ephemeral(fmt.Sprintf("❌ Failed to remove server: %s", err.Error()))
+	}
+	if !removed {
+		return ephemeral(fmt.Sprintf("No server found with ID `%s`. Use `/matrix server list` to see registered servers.", serverID))
+	}
+
+	c.client.Log.Info("Removed managed Matrix server", "server_id", serverID)
+	return ephemeral(fmt.Sprintf("✅ Removed server `%s`.\n\nNote: the primary server from the System Console configuration is re-added automatically; only injected servers can be removed permanently.", serverID))
+}
+
+// executeServerMapCommand maps the current channel to a Matrix room on a specific
+// registered server. Unlike `/matrix map`, which always targets the primary
+// server, this stores the mapping under the chosen server's namespace so inbound
+// events from that homeserver route to this channel. It upserts the channel
+// mapping so a channel already bridged to another server keeps that mapping.
+func (c *Handler) executeServerMapCommand(args *model.CommandArgs, fields []string) *model.CommandResponse {
+	// /matrix server map <server_id> <room_alias|room_id>
+	if len(fields) < 5 {
+		return ephemeral(serverCommandUsage)
+	}
+	serverID := fields[3]
+	roomIdentifier := fields[4]
+
+	servers, err := c.plugin.GetManagedServers()
+	if err != nil {
+		c.client.Log.Error("Failed to read managed servers", "error", err)
+		return ephemeral("❌ Failed to read the server registry. Check plugin logs for details.")
+	}
+	if _, ok := kvstore.ServerConfigForID(servers, serverID); !ok {
+		return ephemeral(fmt.Sprintf("No server found with ID `%s`. Use `/matrix server list` to see registered servers.", serverID))
+	}
+
+	// Resolve the room alias to a room ID and join the AS bot using the target
+	// server's client, so inbound events for the room reach the plugin. The client
+	// is best-effort: if it is unavailable, the identifier is stored as given.
+	roomID := roomIdentifier
+	var joinStatus string
+	if client := c.plugin.GetMatrixClientForServer(serverID); client != nil {
+		if resolved, resolveErr := client.ResolveRoomAlias(roomIdentifier); resolveErr == nil && resolved != "" {
+			roomID = resolved
+		}
+		if joinErr := client.JoinRoom(roomIdentifier); joinErr != nil {
+			c.client.Log.Warn("Failed to join room on target server", "error", joinErr, "server_id", serverID, "room", roomIdentifier)
+			joinStatus = "\n\n⚠️ Could not join the room as the bridge bot; make sure the room exists and is joinable on that server."
+		}
+	} else {
+		joinStatus = "\n\n⚠️ No Matrix client is built for that server yet, so the room alias was not resolved. Pass a room ID (`!...`) if inbound events do not arrive."
+	}
+
+	channelName := args.ChannelId
+	if channel, appErr := c.client.Channel.Get(args.ChannelId); appErr == nil {
+		if channel.DisplayName != "" {
+			channelName = channel.DisplayName
+		} else if channel.Name != "" {
+			channelName = channel.Name
+		}
+	}
+
+	// Upsert the forward mapping so other servers' entries for this channel are
+	// preserved, then store the reverse mapping under the target server.
+	mappingKey := kvstore.BuildChannelMappingKey(args.ChannelId)
+	existing, err := c.kvstore.Get(mappingKey)
+	if err != nil {
+		c.client.Log.Error("Failed to read channel mapping", "error", err, "channel_id", args.ChannelId)
+		return ephemeral("❌ Failed to read the existing channel mapping. Check plugin logs for details.")
+	}
+	mappings, err := kvstore.ParseChannelServerMappings(existing)
+	if err != nil {
+		c.client.Log.Error("Corrupt channel mapping value", "error", err, "channel_id", args.ChannelId)
+		return ephemeral("❌ The existing channel mapping is corrupt. Use `/matrix unmap` and try again.")
+	}
+	mappings = kvstore.UpsertChannelServerMapping(mappings, serverID, roomID)
+	value, err := kvstore.MarshalChannelServerMappings(mappings)
+	if err != nil {
+		c.client.Log.Error("Failed to marshal channel mapping", "error", err, "channel_id", args.ChannelId)
+		return ephemeral("❌ Failed to save the channel mapping. Check plugin logs for details.")
+	}
+	if err := c.kvstore.Set(mappingKey, value); err != nil {
+		c.client.Log.Error("Failed to save channel mapping", "error", err, "channel_id", args.ChannelId)
+		return ephemeral("❌ Failed to save the channel mapping. Check plugin logs for details.")
+	}
+	if err := c.kvstore.Set(kvstore.BuildRoomMappingKey(serverID, roomID), []byte(args.ChannelId)); err != nil {
+		c.client.Log.Error("Failed to save reverse room mapping", "error", err, "server_id", serverID, "room_id", roomID)
+		// The forward mapping is saved; inbound routing still works via it.
+	}
+
+	// Share the channel so inbound posts attribute to the bridge remote.
+	shareStatus := c.shareChannelAndInvitePlugin(args, channelName, fmt.Sprintf("Mapped to Matrix room %s on server %s", roomID, serverID))
+
+	c.client.Log.Info("Mapped channel to room on server", "channel_id", args.ChannelId, "server_id", serverID, "room_id", roomID)
+	return ephemeral(fmt.Sprintf("✅ **Mapping saved**\n\n**Channel:** %s\n**Server:** `%s`\n**Matrix room:** `%s`\n\nInbound events from this room now sync to the channel. (Outbound Mattermost→Matrix for non-primary servers is not yet supported.)%s%s", channelName, serverID, roomID, joinStatus, shareStatus))
+}
+
+// ephemeral builds an ephemeral command response with the given text.
+func ephemeral(text string) *model.CommandResponse {
+	return &model.CommandResponse{
+		ResponseType: model.CommandResponseTypeEphemeral,
+		Text:         text,
 	}
 }
 

--- a/server/command/command_test.go
+++ b/server/command/command_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 	"testing"
@@ -93,6 +94,63 @@ func (m *mockPlugin) RunKVStoreMigrationsWithResults() (*MigrationResult, error)
 func (m *mockPlugin) GetMatrixUserIDFromMattermostUser(mattermostUserID string) (string, error) {
 	// Mock implementation - return test Matrix user
 	return "@test_" + mattermostUserID + ":test.com", nil
+}
+
+func (m *mockPlugin) GetManagedServers() ([]kvstore.ServerConfig, error) {
+	data, err := m.kvstore.Get(kvstore.KeyServersConfig)
+	if err != nil {
+		return nil, err
+	}
+	return kvstore.ParseServersConfig(data)
+}
+
+func (m *mockPlugin) AddManagedServer(serverURL, serverName, asToken, hsToken, usernamePrefix string) (string, error) {
+	servers, _ := m.GetManagedServers()
+	serverID := "srv_" + serverName
+	entry := kvstore.ServerConfig{ServerID: serverID, ServerURL: serverURL, ServerName: serverName, ASToken: asToken, HSToken: hsToken, UsernamePrefix: usernamePrefix, Enabled: true}
+	replaced := false
+	for i := range servers {
+		if servers[i].ServerID == serverID {
+			servers[i] = entry
+			replaced = true
+		}
+	}
+	if !replaced {
+		servers = append(servers, entry)
+	}
+	data, err := json.Marshal(servers)
+	if err != nil {
+		return "", err
+	}
+	if err := m.kvstore.Set(kvstore.KeyServersConfig, data); err != nil {
+		return "", err
+	}
+	return serverID, nil
+}
+
+func (m *mockPlugin) GetMatrixClientForServer(string) *matrix.Client {
+	return m.matrixClient
+}
+
+func (m *mockPlugin) RemoveManagedServer(serverID string) (bool, error) {
+	servers, _ := m.GetManagedServers()
+	filtered := make([]kvstore.ServerConfig, 0, len(servers))
+	found := false
+	for _, s := range servers {
+		if s.ServerID == serverID {
+			found = true
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	if !found {
+		return false, nil
+	}
+	data, err := json.Marshal(filtered)
+	if err != nil {
+		return false, err
+	}
+	return true, m.kvstore.Set(kvstore.KeyServersConfig, data)
 }
 
 func setupTest() *env {
@@ -389,6 +447,24 @@ func setupCommandRegistration(env *env) {
 	matrixData.AddCommand(model.NewAutocompleteData("status", "", statusCommandDesc))
 	matrixData.AddCommand(model.NewAutocompleteData("migrate", "", migrateCommandDesc))
 
+	serverCmd := model.NewAutocompleteData("server", "[list|add|remove]", serverCommandDesc)
+	serverCmd.AddCommand(model.NewAutocompleteData("list", "", "List all registered Matrix servers"))
+	serverAddCmd := model.NewAutocompleteData("add", "<server_url> <server_name> <as_token> <hs_token> [username_prefix]", "Register or replace a Matrix server")
+	serverAddCmd.AddTextArgument("Matrix homeserver base URL", "<server_url>", "")
+	serverAddCmd.AddTextArgument("Matrix server name (domain in user IDs)", "<server_name>", "")
+	serverAddCmd.AddTextArgument("Application Service token", "<as_token>", "")
+	serverAddCmd.AddTextArgument("Homeserver token", "<hs_token>", "")
+	serverAddCmd.AddTextArgument("Optional username prefix", "[username_prefix]", "")
+	serverCmd.AddCommand(serverAddCmd)
+	serverRemoveCmd := model.NewAutocompleteData("remove", "<server_id>", "Remove a registered Matrix server")
+	serverRemoveCmd.AddTextArgument("Server ID (from /matrix server list)", "<server_id>", "")
+	serverCmd.AddCommand(serverRemoveCmd)
+	serverMapCmd := model.NewAutocompleteData("map", "<server_id> <room_alias|room_id>", "Map the current channel to a room on a specific server")
+	serverMapCmd.AddTextArgument("Server ID (from /matrix server list)", "<server_id>", "")
+	serverMapCmd.AddTextArgument("Matrix room alias or room ID", "<room_alias|room_id>", "")
+	serverCmd.AddCommand(serverMapCmd)
+	matrixData.AddCommand(serverCmd)
+
 	env.api.On("RegisterCommand", &model.Command{
 		Trigger:          matrixCommandTrigger,
 		AutoComplete:     true,
@@ -626,7 +702,16 @@ func (s *memKV) GetTemplateData(string) (string, error) { return "", nil }
 func (s *memKV) Get(k string) ([]byte, error)           { return s.m[k], nil }
 func (s *memKV) Set(k string, v []byte) error           { s.m[k] = v; return nil }
 func (s *memKV) Delete(k string) error                  { delete(s.m, k); return nil }
-func (s *memKV) ListKeys(int, int) ([]string, error)    { return nil, nil }
+
+func (s *memKV) SetAtomicWithRetries(k string, valueFunc func(oldValue []byte) ([]byte, error)) error {
+	newValue, err := valueFunc(s.m[k])
+	if err != nil {
+		return err
+	}
+	s.m[k] = newValue
+	return nil
+}
+func (s *memKV) ListKeys(int, int) ([]string, error) { return nil, nil }
 
 func (s *memKV) ListKeysWithPrefix(page, perPage int, prefix string) ([]string, error) {
 	var keys []string

--- a/server/command/server_command_test.go
+++ b/server/command/server_command_test.go
@@ -1,0 +1,136 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/store/kvstore"
+)
+
+// newServerCommandHandler builds a command handler backed by the in-memory
+// mockPlugin, with the command-issuer granted (or denied) system-admin.
+func newServerCommandHandler(t *testing.T, isAdmin bool) (*Handler, *mockPlugin) {
+	t.Helper()
+	env := setupTest()
+	setupCommandRegistration(env)
+	env.api.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(isAdmin).Maybe()
+	env.api.On("HasPermissionTo", mock.Anything, mock.Anything).Return(isAdmin).Maybe()
+	env.api.On("LogInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	env.api.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+	mp := &mockPlugin{
+		client:    env.client,
+		kvstore:   newMemKV(),
+		config:    &mockConfiguration{serverURL: "http://test.com"},
+		pluginAPI: env.api,
+	}
+	handler := NewCommandHandler(mp).(*Handler)
+	return handler, mp
+}
+
+func runServer(h *Handler, command string) *model.CommandResponse {
+	return h.executeMatrixCommand(&model.CommandArgs{Command: command, UserId: "admin-user"})
+}
+
+func TestServerCommandRequiresAdmin(t *testing.T) {
+	handler, _ := newServerCommandHandler(t, false)
+	resp := runServer(handler, "/matrix server list")
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Text, "System Administrator")
+}
+
+func TestServerCommandAddListRemove(t *testing.T) {
+	handler, mp := newServerCommandHandler(t, true)
+
+	// list is empty initially
+	resp := runServer(handler, "/matrix server list")
+	assert.Contains(t, resp.Text, "No Matrix servers are registered")
+
+	// add
+	resp = runServer(handler, "/matrix server add http://synapse2.localhost:8889 synapse2.localhost as_tok hs_tok matrix2")
+	assert.Contains(t, resp.Text, "Server registered")
+	assert.Contains(t, resp.Text, "srv_synapse2.localhost")
+
+	// the registry now holds the injected server
+	servers, err := mp.GetManagedServers()
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	assert.Equal(t, "synapse2.localhost", servers[0].ServerName)
+	assert.Equal(t, "http://synapse2.localhost:8889", servers[0].ServerURL)
+	assert.Equal(t, "hs_tok", servers[0].HSToken)
+	assert.Equal(t, "matrix2", servers[0].UsernamePrefix)
+
+	// list shows it
+	resp = runServer(handler, "/matrix server list")
+	assert.Contains(t, resp.Text, "synapse2.localhost")
+	assert.Contains(t, resp.Text, "enabled")
+
+	// remove
+	resp = runServer(handler, "/matrix server remove srv_synapse2.localhost")
+	assert.Contains(t, resp.Text, "Removed server")
+
+	servers, err = mp.GetManagedServers()
+	require.NoError(t, err)
+	assert.Empty(t, servers)
+}
+
+func TestServerCommandAddValidatesArgs(t *testing.T) {
+	handler, _ := newServerCommandHandler(t, true)
+	// Missing required tokens -> usage message, no server added.
+	resp := runServer(handler, "/matrix server add http://x.localhost synapse")
+	assert.Contains(t, resp.Text, "Usage: /matrix server")
+}
+
+func TestServerCommandRemoveUnknown(t *testing.T) {
+	handler, _ := newServerCommandHandler(t, true)
+	resp := runServer(handler, "/matrix server remove does-not-exist")
+	assert.Contains(t, resp.Text, "No server found")
+}
+
+func TestServerCommandMapUnknownServer(t *testing.T) {
+	handler, _ := newServerCommandHandler(t, true)
+	resp := handler.executeMatrixCommand(&model.CommandArgs{
+		Command:   "/matrix server map does-not-exist !room:synapse2.localhost",
+		UserId:    "admin-user",
+		ChannelId: "chan-1",
+	})
+	assert.Contains(t, resp.Text, "No server found")
+}
+
+func TestServerCommandMapStoresMappingUnderServer(t *testing.T) {
+	handler, mp := newServerCommandHandler(t, true)
+
+	// Register a server (no live client -> map stores the identifier as given).
+	require.Contains(t, runServer(handler, "/matrix server add http://synapse2.localhost:8889 synapse2.localhost as hs matrix2").Text, "Server registered")
+
+	// Channel + share mocks used by the map handler.
+	env := handler.pluginAPI.(*plugintest.API)
+	env.On("GetChannel", "chan-1").Return(&model.Channel{Id: "chan-1", Name: "town-square"}, nil).Maybe()
+	env.On("ShareChannel", mock.Anything).Return(nil, nil).Maybe()
+	env.On("UpdateChannel", mock.Anything).Return(nil, nil).Maybe()
+	env.On("InviteRemoteToChannel", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	resp := handler.executeMatrixCommand(&model.CommandArgs{
+		Command:   "/matrix server map srv_synapse2.localhost !room2:synapse2.localhost",
+		UserId:    "admin-user",
+		ChannelId: "chan-1",
+		TeamId:    "team-1",
+	})
+	require.Contains(t, resp.Text, "Mapping saved")
+
+	// Forward mapping stored under the target server, reverse mapping keyed by it.
+	fwd, err := mp.kvstore.Get(kvstore.BuildChannelMappingKey("chan-1"))
+	require.NoError(t, err)
+	mappings, err := kvstore.ParseChannelServerMappings(fwd)
+	require.NoError(t, err)
+	assert.Equal(t, "!room2:synapse2.localhost", kvstore.RoomIDForServer(mappings, "srv_synapse2.localhost"))
+
+	rev, err := mp.kvstore.Get(kvstore.BuildRoomMappingKey("srv_synapse2.localhost", "!room2:synapse2.localhost"))
+	require.NoError(t, err)
+	assert.Equal(t, "chan-1", string(rev))
+}

--- a/server/matrix_webhook.go
+++ b/server/matrix_webhook.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -35,9 +34,17 @@ type MatrixTransaction struct {
 	Events []MatrixEvent `json:"events"`
 }
 
-// processedTransactions stores transaction IDs to prevent duplicate processing
+// txnKey identifies a processed transaction. Matrix transaction IDs are only
+// unique per homeserver, so the key is scoped by serverID to keep colliding
+// txnIDs from different servers from deduping against each other.
+type txnKey struct {
+	serverID string
+	txnID    string
+}
+
+// processedTransactions stores transaction keys to prevent duplicate processing
 var (
-	processedTransactions = make(map[string]time.Time)
+	processedTransactions = make(map[txnKey]time.Time)
 	transactionsMutex     sync.RWMutex
 )
 
@@ -45,13 +52,13 @@ var (
 func (p *Plugin) cleanupOldTransactions() {
 	cutoff := time.Now().Add(-time.Hour)
 
-	// Create a list of transaction IDs to delete to avoid holding the lock during iteration
-	var toDelete []string
+	// Create a list of transaction keys to delete to avoid holding the lock during iteration
+	var toDelete []txnKey
 
 	transactionsMutex.RLock()
-	for txnID, timestamp := range processedTransactions {
+	for key, timestamp := range processedTransactions {
 		if timestamp.Before(cutoff) {
-			toDelete = append(toDelete, txnID)
+			toDelete = append(toDelete, key)
 		}
 	}
 	transactionsMutex.RUnlock()
@@ -59,10 +66,10 @@ func (p *Plugin) cleanupOldTransactions() {
 	// Delete the old transactions with write lock
 	if len(toDelete) > 0 {
 		transactionsMutex.Lock()
-		for _, txnID := range toDelete {
+		for _, key := range toDelete {
 			// Double-check the timestamp in case it was updated between read and write lock
-			if timestamp, exists := processedTransactions[txnID]; exists && timestamp.Before(cutoff) {
-				delete(processedTransactions, txnID)
+			if timestamp, exists := processedTransactions[key]; exists && timestamp.Before(cutoff) {
+				delete(processedTransactions, key)
 			}
 		}
 		transactionsMutex.Unlock()
@@ -87,11 +94,19 @@ func (p *Plugin) handleMatrixTransaction(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Authentication is handled by MatrixAuthorizationRequired middleware
+	// Authentication is handled by MatrixAuthorizationRequired middleware, which
+	// resolves and injects the originating server's serverID.
+	serverID, ok := serverIDFromContext(r.Context())
+	if !ok || serverID == "" {
+		p.logger.LogError("Matrix webhook reached handler without a resolved server ID", "txn_id", txnID)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	key := txnKey{serverID: serverID, txnID: txnID}
 
 	// Check for duplicate transaction (idempotency)
 	transactionsMutex.RLock()
-	timestamp, exists := processedTransactions[txnID]
+	timestamp, exists := processedTransactions[key]
 	transactionsMutex.RUnlock()
 
 	if exists {
@@ -133,7 +148,7 @@ func (p *Plugin) handleMatrixTransaction(w http.ResponseWriter, r *http.Request)
 
 	// Mark transaction as processed
 	transactionsMutex.Lock()
-	processedTransactions[txnID] = time.Now()
+	processedTransactions[key] = time.Now()
 	shouldCleanup := len(processedTransactions)%100 == 0
 	transactionsMutex.Unlock()
 
@@ -146,7 +161,7 @@ func (p *Plugin) handleMatrixTransaction(w http.ResponseWriter, r *http.Request)
 
 	// Process each event in the transaction
 	for _, event := range transaction.Events {
-		if err := p.processMatrixEvent(event); err != nil {
+		if err := p.processMatrixEvent(serverID, event); err != nil {
 			p.logger.LogError("Failed to process Matrix event", "error", err, "event_id", event.EventID, "event_type", event.Type, "room_id", event.RoomID, "txn_id", txnID)
 			// Continue processing other events even if one fails
 			continue
@@ -162,10 +177,12 @@ func (p *Plugin) handleMatrixTransaction(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-// processMatrixEvent routes a single Matrix event to the appropriate handler
-func (p *Plugin) processMatrixEvent(event MatrixEvent) error {
+// processMatrixEvent routes a single Matrix event to the appropriate handler.
+// serverID identifies the originating homeserver (resolved from its hs_token) and
+// scopes every lookup, KV namespace and Matrix client used to process the event.
+func (p *Plugin) processMatrixEvent(serverID string, event MatrixEvent) error {
 	// Check if we have an existing mapping for this room
-	channelID, err := p.getChannelIDFromMatrixRoom(event.RoomID)
+	channelID, err := p.getChannelIDFromMatrixRoom(serverID, event.RoomID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get channel ID from Matrix room")
 	}
@@ -175,7 +192,7 @@ func (p *Plugin) processMatrixEvent(event MatrixEvent) error {
 		// Only attempt DM creation for room membership events or messages
 		if event.Type == "m.room.member" || event.Type == "m.room.message" {
 			// Check if this is a Matrix-initiated DM that we should bridge
-			newChannelID, err := p.handleMatrixInitiatedDM(event)
+			newChannelID, err := p.handleMatrixInitiatedDM(serverID, event)
 			if err != nil {
 				p.logger.LogWarn("Failed to handle Matrix-initiated DM", "room_id", event.RoomID, "error", err)
 				return nil // Don't error - just skip processing
@@ -194,23 +211,24 @@ func (p *Plugin) processMatrixEvent(event MatrixEvent) error {
 	}
 
 	// Skip events from our own ghost users to prevent loops
-	if p.isGhostUser(event.Sender) {
+	if p.isGhostUser(serverID, event.Sender) {
 		p.logger.LogDebug("Ignoring event from ghost user", "sender", event.Sender, "event_type", event.Type, "room_id", event.RoomID)
 		return nil
 	}
 
 	p.logger.LogDebug("Processing Matrix event", "event_id", event.EventID, "event_type", event.Type, "sender", event.Sender, "room_id", event.RoomID, "channel_id", channelID)
 
-	// Route event based on type
+	// Route event based on type, using a bridge scoped to the originating server.
+	bridge := p.newMatrixToMattermostBridge(serverID)
 	switch event.Type {
 	case "m.room.message":
-		return p.matrixToMattermostBridge.syncMatrixMessageToMattermost(event, channelID)
+		return bridge.syncMatrixMessageToMattermost(event, channelID)
 	case "m.reaction":
-		return p.matrixToMattermostBridge.syncMatrixReactionToMattermost(event, channelID)
+		return bridge.syncMatrixReactionToMattermost(event, channelID)
 	case "m.room.member":
-		return p.matrixToMattermostBridge.syncMatrixMemberEventToMattermost(event, channelID)
+		return bridge.syncMatrixMemberEventToMattermost(event, channelID)
 	case "m.room.redaction":
-		return p.matrixToMattermostBridge.syncMatrixRedactionToMattermost(event, channelID)
+		return bridge.syncMatrixRedactionToMattermost(event, channelID)
 	default:
 		p.logger.LogDebug("Ignoring unsupported event type", "event_type", event.Type, "event_id", event.EventID, "room_id", event.RoomID)
 		return nil
@@ -218,9 +236,10 @@ func (p *Plugin) processMatrixEvent(event MatrixEvent) error {
 }
 
 // getChannelIDFromMatrixRoom finds the Mattermost channel ID for a Matrix room ID
-func (p *Plugin) getChannelIDFromMatrixRoom(roomID string) (string, error) {
-	// First check KV store mapping (trusted source): room_mapping_<roomID> -> channelID
-	roomMappingKey := kvstore.BuildRoomMappingKey(p.getSingleServerID(), roomID)
+// within the given server's KV namespace.
+func (p *Plugin) getChannelIDFromMatrixRoom(serverID, roomID string) (string, error) {
+	// First check KV store mapping (trusted source): room_mapping_<serverID>_<roomID> -> channelID
+	roomMappingKey := kvstore.BuildRoomMappingKey(serverID, roomID)
 	channelIDBytes, err := p.kvstore.Get(roomMappingKey)
 	if err == nil && len(channelIDBytes) > 0 {
 		channelID := string(channelIDBytes)
@@ -229,7 +248,7 @@ func (p *Plugin) getChannelIDFromMatrixRoom(roomID string) (string, error) {
 	}
 
 	// Fallback: get channel ID from Matrix room state (for race condition during room creation)
-	matrixClient := p.GetMatrixClient()
+	matrixClient := p.getMatrixClient(serverID)
 	if matrixClient != nil {
 		channelID, err := matrixClient.GetMattermostChannelID(roomID)
 		if err != nil {
@@ -243,21 +262,16 @@ func (p *Plugin) getChannelIDFromMatrixRoom(roomID string) (string, error) {
 	return "", nil // No mapping found
 }
 
-// isGhostUser checks if a Matrix user ID belongs to one of our ghost users
-func (p *Plugin) isGhostUser(userID string) bool {
-	config := p.getConfiguration()
-	if config.MatrixServerURL == "" {
-		p.logger.LogDebug("isGhostUser: no MatrixServerURL configured", "user_id", userID)
+// isGhostUser checks if a Matrix user ID belongs to one of our ghost users on the
+// given server. Ghost users end in ":<server_domain>", so the check is scoped to
+// the originating server's domain rather than a single global config.
+func (p *Plugin) isGhostUser(serverID, userID string) bool {
+	// Extract server domain (the real domain, not sanitized for property keys).
+	serverDomain, ok := p.serverDomainForID(serverID)
+	if !ok {
+		p.logger.LogDebug("isGhostUser: could not resolve server domain", "server_id", serverID, "user_id", userID)
 		return false
 	}
-
-	// Extract server domain (get the real domain, not sanitized for property keys)
-	parsedURL, err := url.Parse(config.MatrixServerURL)
-	if err != nil || parsedURL.Hostname() == "" {
-		p.logger.LogDebug("isGhostUser: failed to parse MatrixServerURL", "url", config.MatrixServerURL, "error", err)
-		return false
-	}
-	serverDomain := parsedURL.Hostname()
 
 	// Ghost users follow the pattern: @_mattermost_<mattermost_user_id>:<server_domain>
 	ghostUserPrefix := "@_mattermost_"
@@ -268,11 +282,11 @@ func (p *Plugin) isGhostUser(userID string) bool {
 
 // handleMatrixInitiatedDM checks if an unmapped Matrix room is a potential DM that should be bridged
 // This uses a heuristic approach based on the event information available
-func (p *Plugin) handleMatrixInitiatedDM(event MatrixEvent) (string, error) {
+func (p *Plugin) handleMatrixInitiatedDM(serverID string, event MatrixEvent) (string, error) {
 	// Handle different event types that might indicate DM creation
 	switch event.Type {
 	case "m.room.member":
-		return p.handleMatrixMemberDM(event)
+		return p.handleMatrixMemberDM(serverID, event)
 	case "m.room.message":
 		return p.handleMatrixMessageDM(event)
 	default:
@@ -281,7 +295,7 @@ func (p *Plugin) handleMatrixInitiatedDM(event MatrixEvent) (string, error) {
 }
 
 // handleMatrixMemberDM processes member events to detect DM room creation with ghost users
-func (p *Plugin) handleMatrixMemberDM(event MatrixEvent) (string, error) {
+func (p *Plugin) handleMatrixMemberDM(serverID string, event MatrixEvent) (string, error) {
 	// Only handle join events to avoid creating channels for leave/invite events
 	if event.Content == nil {
 		p.logger.LogDebug("Member event has no content", "room_id", event.RoomID, "event_id", event.EventID)
@@ -308,11 +322,11 @@ func (p *Plugin) handleMatrixMemberDM(event MatrixEvent) (string, error) {
 	// Check if either user is one of our ghost users
 	var ghostUserID, matrixUserID string
 	switch {
-	case p.isGhostUser(targetUserID):
+	case p.isGhostUser(serverID, targetUserID):
 		ghostUserID = targetUserID
 		matrixUserID = actingUserID
 		p.logger.LogDebug("Detected ghost user as target", "room_id", event.RoomID, "ghost_user", ghostUserID, "matrix_user", matrixUserID, "membership", membership)
-	case p.isGhostUser(actingUserID):
+	case p.isGhostUser(serverID, actingUserID):
 		ghostUserID = actingUserID
 		matrixUserID = targetUserID
 		p.logger.LogDebug("Detected ghost user as actor", "room_id", event.RoomID, "ghost_user", ghostUserID, "matrix_user", matrixUserID, "membership", membership)
@@ -322,7 +336,7 @@ func (p *Plugin) handleMatrixMemberDM(event MatrixEvent) (string, error) {
 		return "", nil
 	}
 
-	return p.createDMChannelForGhostUser(event.RoomID, ghostUserID, matrixUserID)
+	return p.createDMChannelForGhostUser(serverID, event.RoomID, ghostUserID, matrixUserID)
 }
 
 // handleMatrixMessageDM processes message events that might be in a DM with a ghost user
@@ -338,7 +352,7 @@ func (p *Plugin) handleMatrixMessageDM(event MatrixEvent) (string, error) {
 }
 
 // createDMChannelForGhostUser creates a Mattermost DM channel for a Matrix DM involving a verified ghost user
-func (p *Plugin) createDMChannelForGhostUser(roomID, ghostUserID, matrixUserID string) (string, error) {
+func (p *Plugin) createDMChannelForGhostUser(serverID, roomID, ghostUserID, matrixUserID string) (string, error) {
 	// Extract Mattermost user ID from ghost user
 	mattermostUserID := p.extractMattermostUserIDFromGhost(ghostUserID)
 	if mattermostUserID == "" {
@@ -346,7 +360,7 @@ func (p *Plugin) createDMChannelForGhostUser(roomID, ghostUserID, matrixUserID s
 	}
 
 	// Verify that this ghost user exists in our KV store (meaning we created it)
-	ghostUserKey := kvstore.BuildGhostUserKey(p.getSingleServerID(), mattermostUserID)
+	ghostUserKey := kvstore.BuildGhostUserKey(serverID, mattermostUserID)
 	ghostUserData, err := p.kvstore.Get(ghostUserKey)
 	if err != nil || len(ghostUserData) == 0 {
 		p.logger.LogDebug("Rejecting DM creation for unrecognized ghost user", "ghost_user_id", ghostUserID, "mattermost_user_id", mattermostUserID)
@@ -366,18 +380,9 @@ func (p *Plugin) createDMChannelForGhostUser(roomID, ghostUserID, matrixUserID s
 		return "", errors.Wrap(appErr, "failed to get Mattermost user")
 	}
 
-	// Get or create the Matrix user in Mattermost
-	bridgeUtils := NewBridgeUtils(BridgeUtilsConfig{
-		Logger:       p.logger,
-		API:          p.API,
-		KVStore:      p.kvstore,
-		MatrixClient: p.GetMatrixClient(),
-		ServerID:     p.getSingleServerID(),
-		RemoteID:     p.remoteID,
-		ConfigGetter: p,
-	})
-
-	matrixToMattermostBridge := NewMatrixToMattermostBridge(bridgeUtils)
+	// Get or create the Matrix user in Mattermost, using a bridge scoped to the
+	// originating server.
+	matrixToMattermostBridge := p.newMatrixToMattermostBridge(serverID)
 
 	// Create or get the Matrix user in Mattermost (using a dummy team - will be fixed by addUserToChannelTeam)
 	mattermostMatrixUserID, err := matrixToMattermostBridge.getOrCreateMattermostUser(matrixUserID, "")
@@ -392,7 +397,7 @@ func (p *Plugin) createDMChannelForGhostUser(roomID, ghostUserID, matrixUserID s
 	}
 
 	// Store the mapping between Matrix room and Mattermost channel
-	err = bridgeUtils.setChannelRoomMapping(dmChannel.Id, roomID)
+	err = matrixToMattermostBridge.setChannelRoomMapping(dmChannel.Id, roomID)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to store channel room mapping")
 	}

--- a/server/matrix_webhook_test.go
+++ b/server/matrix_webhook_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/store/kvstore"
 )
 
 func TestHandleMatrixMemberDM_EarlyExits(t *testing.T) {
@@ -66,12 +69,51 @@ func TestHandleMatrixMemberDM_EarlyExits(t *testing.T) {
 			plugin := &Plugin{}
 			plugin.logger = &testLogger{t: t}
 
-			channelID, err := plugin.handleMatrixMemberDM(tt.event)
+			// These cases all early-exit before ghost detection, so no server
+			// registry is needed; any serverID is fine.
+			channelID, err := plugin.handleMatrixMemberDM(testServerID, tt.event)
 
 			require.NoError(t, err)
 			assert.Equal(t, "", channelID)
 		})
 	}
+}
+
+// TestIsGhostUserPerServer verifies that ghost-user (loop-prevention) detection is
+// scoped to each server's own domain. A ghost minted on one server's domain must be
+// recognized only for events originating from that server; misresolving the domain
+// would either fail to skip the plugin's own echoes (message loops) or misclassify a
+// real Matrix user as a ghost (dropped inbound messages).
+func TestIsGhostUserPerServer(t *testing.T) {
+	const (
+		serverAID = "serveraserveraserveraserv01"
+		serverBID = "serverbserverbserverbserv02"
+	)
+
+	plugin := &Plugin{}
+	plugin.logger = &testLogger{t: t}
+	plugin.kvstore = NewMemoryKVStore()
+
+	// ServerURL hostname is the source of the ghost domain (see serverDomainForID),
+	// so set each server's URL host to match the domain used in its ghost IDs.
+	servers := []kvstore.ServerConfig{
+		{ServerID: serverAID, ServerURL: "https://synapse-a.local", ServerName: "synapse-a.local"},
+		{ServerID: serverBID, ServerURL: "https://synapse-b.local", ServerName: "synapse-b.local"},
+	}
+	data, err := json.Marshal(servers)
+	require.NoError(t, err)
+	require.NoError(t, plugin.kvstore.Set(kvstore.KeyServersConfig, data))
+
+	ghostA := "@_mattermost_abc123:synapse-a.local"
+
+	assert.True(t, plugin.isGhostUser(serverAID, ghostA),
+		"a server-A ghost is recognized for server-A events")
+	assert.False(t, plugin.isGhostUser(serverBID, ghostA),
+		"a server-A ghost is NOT a ghost for server-B events (different domain)")
+	assert.False(t, plugin.isGhostUser(serverAID, "@alice:synapse-a.local"),
+		"a real Matrix user is not a ghost")
+	assert.False(t, plugin.isGhostUser("unknown-server-id", ghostA),
+		"an unresolvable server yields false rather than a false positive")
 }
 
 func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
@@ -87,6 +129,8 @@ func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
 		plugin.logger = &testLogger{t: t}
 		plugin.configuration = &configuration{MatrixServerURL: matrixServerURL}
 		plugin.kvstore = NewMemoryKVStore()
+		// Seed the registry so isGhostUser can resolve the server's domain by ID.
+		seedTestServerConfig(plugin)
 		return plugin
 	}
 
@@ -101,7 +145,7 @@ func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
 			Content:  map[string]any{"membership": "join"},
 		}
 
-		channelID, err := plugin.handleMatrixMemberDM(event)
+		channelID, err := plugin.handleMatrixMemberDM(testServerID, event)
 
 		require.NoError(t, err)
 		assert.Equal(t, "", channelID)
@@ -119,7 +163,7 @@ func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
 		}
 
 		// Ghost not registered in kvstore → createDMChannelForGhostUser returns "", nil silently
-		channelID, err := plugin.handleMatrixMemberDM(event)
+		channelID, err := plugin.handleMatrixMemberDM(testServerID, event)
 
 		require.NoError(t, err)
 		assert.Equal(t, "", channelID)
@@ -137,7 +181,7 @@ func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
 		}
 
 		// Ghost not registered in kvstore → createDMChannelForGhostUser returns "", nil silently
-		channelID, err := plugin.handleMatrixMemberDM(event)
+		channelID, err := plugin.handleMatrixMemberDM(testServerID, event)
 
 		require.NoError(t, err)
 		assert.Equal(t, "", channelID)
@@ -155,7 +199,7 @@ func TestHandleMatrixMemberDM_SwitchRouting(t *testing.T) {
 		}
 
 		// Neither user is ghost → default case → returns "", nil
-		channelID, err := plugin.handleMatrixMemberDM(event)
+		channelID, err := plugin.handleMatrixMemberDM(testServerID, event)
 
 		require.NoError(t, err)
 		assert.Equal(t, "", channelID)

--- a/server/mocks/mock_kvstore.go
+++ b/server/mocks/mock_kvstore.go
@@ -126,3 +126,17 @@ func (mr *MockKVStoreMockRecorder) Set(key, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockKVStore)(nil).Set), key, value)
 }
+
+// SetAtomicWithRetries mocks base method.
+func (m *MockKVStore) SetAtomicWithRetries(key string, valueFunc func([]byte) ([]byte, error)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetAtomicWithRetries", key, valueFunc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetAtomicWithRetries indicates an expected call of SetAtomicWithRetries.
+func (mr *MockKVStoreMockRecorder) SetAtomicWithRetries(key, valueFunc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAtomicWithRetries", reflect.TypeOf((*MockKVStore)(nil).SetAtomicWithRetries), key, valueFunc)
+}

--- a/server/multi_server_integration_test.go
+++ b/server/multi_server_integration_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
@@ -23,14 +27,15 @@ const (
 	multiServerBID = "serverbserverbserverbserv02"
 )
 
-// MultiServerIntegrationTestSuite verifies the multi-server backend plumbing —
-// the client registry, serverID-namespaced KV, and per-server bridge operations —
-// against two independent, live Synapse homeservers.
+// MultiServerIntegrationTestSuite verifies multi-server behavior — the client
+// registry, serverID-namespaced KV, per-server bridge operations, and inbound
+// routing — against two independent, live Synapse homeservers.
 //
-// Scope note: the plugin provides the multi-server backend plumbing but not
-// cross-server routing (inbound/outbound server selection is still single-server).
-// These tests therefore exercise the registry and per-server isolation directly,
-// not an end-to-end message flow across the two servers.
+// Scope note: inbound (Matrix→Mattermost) routing is now per-server — traffic is
+// dispatched to the originating homeserver by its hs_token, as the TestInbound*
+// tests exercise end-to-end. Outbound (Mattermost→Matrix) routing is still
+// single-server (a later phase); the outbound tests here therefore drive per-server
+// bridges directly rather than through channel-based server selection.
 type MultiServerIntegrationTestSuite struct {
 	suite.Suite
 	containerA *matrixtest.Container
@@ -82,6 +87,14 @@ func (suite *MultiServerIntegrationTestSuite) SetupTest() {
 	plugin.maxProfileImageSize = DefaultMaxProfileImageSize
 	plugin.maxFileSize = DefaultMaxFileSize
 
+	// EnableSync is the master gate checked by the inbound auth middleware.
+	plugin.configuration = &configuration{EnableSync: true}
+
+	// The transaction handler logs the raw body through this logger.
+	transactionLogger, err := CreateTransactionLogger()
+	suite.Require().NoError(err)
+	plugin.transactionLogger = transactionLogger
+
 	// Client registry with one client per homeserver.
 	plugin.matrixClients = map[string]*matrix.Client{
 		multiServerAID: suite.containerA.Client,
@@ -89,16 +102,35 @@ func (suite *MultiServerIntegrationTestSuite) SetupTest() {
 	}
 	plugin.serverID = multiServerAID // GetMatrixClient()/getSingleServerID() default
 
-	// Registry entries mirroring what reconcileServerConfig would persist.
+	// Registry entries mirroring what reconcileServerConfig would persist. Each
+	// server carries its own hs_token so the auth middleware can resolve the
+	// originating server from the presented bearer token.
 	servers := []kvstore.ServerConfig{
-		{ServerID: multiServerAID, ServerURL: suite.containerA.ServerURL, ServerName: suite.containerA.ServerDomain, UsernamePrefix: "matrixa", Enabled: true, RemoteID: plugin.remoteID},
-		{ServerID: multiServerBID, ServerURL: suite.containerB.ServerURL, ServerName: suite.containerB.ServerDomain, UsernamePrefix: "matrixb", Enabled: true, RemoteID: plugin.remoteID},
+		{ServerID: multiServerAID, ServerURL: suite.containerA.ServerURL, ServerName: suite.containerA.ServerDomain, ASToken: suite.containerA.ASToken, HSToken: suite.containerA.HSToken, UsernamePrefix: "matrixa", Enabled: true, RemoteID: plugin.remoteID},
+		{ServerID: multiServerBID, ServerURL: suite.containerB.ServerURL, ServerName: suite.containerB.ServerDomain, ASToken: suite.containerB.ASToken, HSToken: suite.containerB.HSToken, UsernamePrefix: "matrixb", Enabled: true, RemoteID: plugin.remoteID},
 	}
 	data, err := json.Marshal(servers)
 	suite.Require().NoError(err)
 	suite.Require().NoError(plugin.kvstore.Set(kvstore.KeyServersConfig, data))
 
+	// The transaction handler reads the server config to bound the request body size.
+	suite.api.On("GetConfig").Return(&model.Config{}).Maybe()
+
 	suite.plugin = plugin
+}
+
+// putTransaction drives an Application Service transaction through the full HTTP
+// stack (auth middleware + handler) using the given bearer token, returning the
+// HTTP status code.
+func (suite *MultiServerIntegrationTestSuite) putTransaction(bearerToken, txnID string, events []MatrixEvent) int {
+	body, err := json.Marshal(MatrixTransaction{Events: events})
+	suite.Require().NoError(err)
+
+	req := httptest.NewRequest(http.MethodPut, "/_matrix/app/v1/transactions/"+txnID, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	rec := httptest.NewRecorder()
+	suite.plugin.ServeHTTP(nil, rec, req)
+	return rec.Code
 }
 
 // bridgeFor builds a MattermostToMatrixBridge scoped to a single server, as the
@@ -227,6 +259,359 @@ func (suite *MultiServerIntegrationTestSuite) TestGhostUsersAreCreatedPerServer(
 	ghostA2, err := bridgeA.CreateOrGetGhostUser(mmUserID)
 	require.NoError(t, err)
 	assert.Equal(t, ghostA, ghostA2)
+}
+
+// TestInboundAuthRoutesByHSToken verifies the auth middleware resolves the
+// originating server from the presented hs_token and rejects unknown tokens.
+func (suite *MultiServerIntegrationTestSuite) TestInboundAuthRoutesByHSToken() {
+	t := suite.T()
+
+	// A probe handler records the serverID the middleware injected into the context.
+	var resolvedServerID string
+	var handlerRan bool
+	probe := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerRan = true
+		resolvedServerID, _ = serverIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := suite.plugin.MatrixAuthorizationRequired(probe)
+
+	serve := func(bearer string) (int, string, bool) {
+		resolvedServerID, handlerRan = "", false
+		req := httptest.NewRequest(http.MethodPut, "/_matrix/app/v1/transactions/txn1", nil)
+		if bearer != "" {
+			req.Header.Set("Authorization", "Bearer "+bearer)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code, resolvedServerID, handlerRan
+	}
+
+	// Each homeserver's real hs_token resolves to its own serverID.
+	status, serverID, ran := serve(suite.containerA.HSToken)
+	assert.Equal(t, http.StatusOK, status)
+	assert.True(t, ran)
+	assert.Equal(t, multiServerAID, serverID)
+
+	status, serverID, ran = serve(suite.containerB.HSToken)
+	assert.Equal(t, http.StatusOK, status)
+	assert.True(t, ran)
+	assert.Equal(t, multiServerBID, serverID)
+
+	// An unknown token is rejected and the handler never runs.
+	status, _, ran = serve("not-a-valid-token")
+	assert.Equal(t, http.StatusUnauthorized, status)
+	assert.False(t, ran)
+}
+
+// TestInboundTransactionDedupIsPerServer verifies that the same txnID from two
+// different servers is processed independently, while a repeat from the same
+// server is deduplicated.
+func (suite *MultiServerIntegrationTestSuite) TestInboundTransactionDedupIsPerServer() {
+	t := suite.T()
+
+	// Isolate this test from any residual state in the process-global map.
+	transactionsMutex.Lock()
+	processedTransactions = make(map[txnKey]time.Time)
+	transactionsMutex.Unlock()
+
+	const sharedTxnID = "shared-txn-id-across-servers"
+
+	hasKey := func(serverID string) bool {
+		transactionsMutex.RLock()
+		defer transactionsMutex.RUnlock()
+		_, ok := processedTransactions[txnKey{serverID: serverID, txnID: sharedTxnID}]
+		return ok
+	}
+
+	// Empty-event transactions exercise dedup without any Mattermost side effects.
+	assert.Equal(t, http.StatusOK, suite.putTransaction(suite.containerA.HSToken, sharedTxnID, nil))
+	assert.True(t, hasKey(multiServerAID), "server A transaction should be recorded")
+	assert.False(t, hasKey(multiServerBID), "server B must not be marked by server A's transaction")
+
+	// The same txnID from server B is a distinct key, not a duplicate.
+	assert.Equal(t, http.StatusOK, suite.putTransaction(suite.containerB.HSToken, sharedTxnID, nil))
+	assert.True(t, hasKey(multiServerBID), "server B transaction should be recorded independently")
+
+	// A repeat from server A hits the per-(serverID,txnID) dedup path and is a no-op.
+	firstTime := func() time.Time {
+		transactionsMutex.RLock()
+		defer transactionsMutex.RUnlock()
+		return processedTransactions[txnKey{serverID: multiServerAID, txnID: sharedTxnID}]
+	}()
+	assert.Equal(t, http.StatusOK, suite.putTransaction(suite.containerA.HSToken, sharedTxnID, nil))
+	assert.Equal(t, firstTime, func() time.Time {
+		transactionsMutex.RLock()
+		defer transactionsMutex.RUnlock()
+		return processedTransactions[txnKey{serverID: multiServerAID, txnID: sharedTxnID}]
+	}(), "duplicate transaction must not update the recorded timestamp")
+}
+
+// TestInboundMessageRoutesToOriginatingServerNamespace verifies that an inbound
+// message authenticated with one server's hs_token is processed against that
+// server's KV namespace, and that a message for a room only mapped on server A
+// is ignored when presented as server B (lookups are server-scoped).
+func (suite *MultiServerIntegrationTestSuite) TestInboundMessageRoutesToOriginatingServerNamespace() {
+	t := suite.T()
+
+	channelID := model.NewId()
+	mmUserID := model.NewId()
+	sender := "@router_probe:" + suite.containerA.ServerDomain
+	roomA := "!routed-room-a:" + suite.containerA.ServerDomain
+
+	// The room is mapped to a channel only under server A's namespace.
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerAID, roomA), []byte(channelID)))
+	// The sender is already mapped to a Mattermost user under server A, so no ghost
+	// user is created; the profile refresh against server A's live client is
+	// best-effort and no-ops for this synthetic user.
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixUserKey(multiServerAID, sender), []byte(mmUserID)))
+
+	suite.api.On("GetUser", mmUserID).Return(&model.User{Id: mmUserID, Username: "router_probe"}, nil).Maybe()
+	suite.api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, TeamId: ""}, nil).Maybe()
+	var createdPost *model.Post
+	suite.api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(func(post *model.Post) *model.Post {
+		if post.Id == "" {
+			post.Id = model.NewId()
+		}
+		createdPost = post
+		return post
+	}, nil).Maybe()
+
+	event := MatrixEvent{
+		Type:      "m.room.message",
+		EventID:   "$routed-event-a",
+		Sender:    sender,
+		RoomID:    roomA,
+		Content:   map[string]any{"msgtype": "m.text", "body": "hello from server A"},
+		Timestamp: 1,
+	}
+
+	// Presented as server A: the message is synced and its event→post mapping is
+	// written under server A's namespace only.
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerA.HSToken, "txn-routing-a", []MatrixEvent{event}))
+	require.NotNil(t, createdPost, "server A message should create a Mattermost post")
+	assert.Equal(t, channelID, createdPost.ChannelId)
+
+	postMappingA, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerAID, event.EventID))
+	require.NoError(t, err)
+	assert.Equal(t, createdPost.Id, string(postMappingA), "event→post mapping should be stored under server A")
+
+	postMappingB, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerBID, event.EventID))
+	require.NoError(t, err)
+	assert.Empty(t, postMappingB, "server B namespace must be untouched")
+
+	// Presented as server B: the same room is unmapped in server B's namespace, so
+	// the event is ignored and no additional post is created.
+	createdPost = nil
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerB.HSToken, "txn-routing-b", []MatrixEvent{event}))
+	assert.Nil(t, createdPost, "server B has no mapping for this room, so no post should be created")
+}
+
+// TestInboundMessageDeliversToSecondServer is the symmetric counterpart to the
+// routing test above: it proves an inbound message authenticated with server B's
+// hs_token is actually *delivered* (a post is created) and that its state lands in
+// server B's namespace, never server A's. Without this, a bug binding the inbound
+// bridge to the wrong client/namespace would pass as long as server A worked.
+func (suite *MultiServerIntegrationTestSuite) TestInboundMessageDeliversToSecondServer() {
+	t := suite.T()
+
+	channelID := model.NewId()
+	mmUserID := model.NewId()
+	sender := "@router_probe_b:" + suite.containerB.ServerDomain
+	roomB := "!routed-room-b:" + suite.containerB.ServerDomain
+
+	// Map the room and sender only under server B's namespace.
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerBID, roomB), []byte(channelID)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixUserKey(multiServerBID, sender), []byte(mmUserID)))
+
+	suite.api.On("GetUser", mmUserID).Return(&model.User{Id: mmUserID, Username: "router_probe_b"}, nil).Maybe()
+	suite.api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, TeamId: ""}, nil).Maybe()
+	var createdPost *model.Post
+	suite.api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(func(post *model.Post) *model.Post {
+		if post.Id == "" {
+			post.Id = model.NewId()
+		}
+		createdPost = post
+		return post
+	}, nil).Maybe()
+
+	event := MatrixEvent{
+		Type:      "m.room.message",
+		EventID:   "$routed-event-b",
+		Sender:    sender,
+		RoomID:    roomB,
+		Content:   map[string]any{"msgtype": "m.text", "body": "hello from server B"},
+		Timestamp: 1,
+	}
+
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerB.HSToken, "txn-b-deliver", []MatrixEvent{event}))
+	require.NotNil(t, createdPost, "server B message should create a Mattermost post")
+	assert.Equal(t, channelID, createdPost.ChannelId)
+
+	postMappingB, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerBID, event.EventID))
+	require.NoError(t, err)
+	assert.Equal(t, createdPost.Id, string(postMappingB), "event→post mapping should be stored under server B")
+
+	postMappingA, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerAID, event.EventID))
+	require.NoError(t, err)
+	assert.Empty(t, postMappingA, "server A namespace must be untouched")
+}
+
+// TestInboundMessagesFromBothServersRouteToTheirOwnChannels is the definitive
+// end-to-end check: with two live homeservers configured at once, and two distinct
+// Mattermost channels each bridged to a room on a *different* server, an inbound
+// message from each server must land in that server's channel and only that channel.
+// It cross-checks both the positive delivery (A→channelA, B→channelB) and the
+// negative (A's event never touches channelB or server B's namespace, and vice
+// versa) within a single scenario.
+func (suite *MultiServerIntegrationTestSuite) TestInboundMessagesFromBothServersRouteToTheirOwnChannels() {
+	t := suite.T()
+
+	// Two distinct channels, each mapped to a room on a different server's namespace.
+	channelA := model.NewId()
+	channelB := model.NewId()
+	require.NotEqual(t, channelA, channelB)
+
+	userA := model.NewId()
+	userB := model.NewId()
+	senderA := "@sender_a:" + suite.containerA.ServerDomain
+	senderB := "@sender_b:" + suite.containerB.ServerDomain
+	roomA := "!both-room-a:" + suite.containerA.ServerDomain
+	roomB := "!both-room-b:" + suite.containerB.ServerDomain
+	const eventAID = "$both-event-a"
+	const eventBID = "$both-event-b"
+
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerAID, roomA), []byte(channelA)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerBID, roomB), []byte(channelB)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixUserKey(multiServerAID, senderA), []byte(userA)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixUserKey(multiServerBID, senderB), []byte(userB)))
+
+	suite.api.On("GetUser", userA).Return(&model.User{Id: userA, Username: "sender_a"}, nil).Maybe()
+	suite.api.On("GetUser", userB).Return(&model.User{Id: userB, Username: "sender_b"}, nil).Maybe()
+	suite.api.On("GetChannel", channelA).Return(&model.Channel{Id: channelA, TeamId: ""}, nil).Maybe()
+	suite.api.On("GetChannel", channelB).Return(&model.Channel{Id: channelB, TeamId: ""}, nil).Maybe()
+
+	// Capture every created post so we can look each up by ID afterwards.
+	createdPosts := map[string]*model.Post{}
+	suite.api.On("CreatePost", mock.AnythingOfType("*model.Post")).Return(func(post *model.Post) *model.Post {
+		if post.Id == "" {
+			post.Id = model.NewId()
+		}
+		createdPosts[post.Id] = post
+		return post
+	}, nil).Maybe()
+
+	msg := func(eventID, sender, roomID, body string) MatrixEvent {
+		return MatrixEvent{
+			Type:      "m.room.message",
+			EventID:   eventID,
+			Sender:    sender,
+			RoomID:    roomID,
+			Content:   map[string]any{"msgtype": "m.text", "body": body},
+			Timestamp: 1,
+		}
+	}
+
+	// Deliver one message from each server, each authenticated with its own hs_token.
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerA.HSToken, "txn-both-a", []MatrixEvent{msg(eventAID, senderA, roomA, "from A")}))
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerB.HSToken, "txn-both-b", []MatrixEvent{msg(eventBID, senderB, roomB, "from B")}))
+
+	// Resolve each event to its post via the originating server's namespace.
+	postIDA, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerAID, eventAID))
+	require.NoError(t, err)
+	postIDB, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerBID, eventBID))
+	require.NoError(t, err)
+	require.NotEmpty(t, postIDA, "server A event should map to a post")
+	require.NotEmpty(t, postIDB, "server B event should map to a post")
+
+	postA := createdPosts[string(postIDA)]
+	postB := createdPosts[string(postIDB)]
+	require.NotNil(t, postA, "server A message should create a post")
+	require.NotNil(t, postB, "server B message should create a post")
+
+	// Positive: each message landed in its own server's channel.
+	assert.Equal(t, channelA, postA.ChannelId, "server A message routes to channel A")
+	assert.Equal(t, "from A", postA.Message)
+	assert.Equal(t, channelB, postB.ChannelId, "server B message routes to channel B")
+	assert.Equal(t, "from B", postB.Message)
+
+	// Negative cross-checks: neither message leaked into the other channel...
+	assert.NotEqual(t, channelB, postA.ChannelId, "server A message must NOT land in channel B")
+	assert.NotEqual(t, channelA, postB.ChannelId, "server B message must NOT land in channel A")
+
+	// ...and neither event appears in the other server's namespace.
+	crossA, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerBID, eventAID))
+	require.NoError(t, err)
+	assert.Empty(t, crossA, "server A's event must not appear under server B's namespace")
+	crossB, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixEventPostKey(multiServerAID, eventBID))
+	require.NoError(t, err)
+	assert.Empty(t, crossB, "server B's event must not appear under server A's namespace")
+}
+
+// TestInboundReactionRoutesToOriginatingServerNamespace verifies that an inbound
+// reaction resolves its target post and stores its mapping within the originating
+// server's namespace, and that the same reaction presented as a different server
+// does not resolve across namespaces.
+func (suite *MultiServerIntegrationTestSuite) TestInboundReactionRoutesToOriginatingServerNamespace() {
+	t := suite.T()
+
+	channelID := model.NewId()
+	postID := model.NewId()
+	reactorMMUserID := model.NewId()
+	reactor := "@reactor:" + suite.containerA.ServerDomain
+	roomA := "!reaction-room-a:" + suite.containerA.ServerDomain
+	const targetEventID = "$reaction-target-a"
+	const reactionEventID = "$reaction-event-a"
+
+	// Seed, under server A's namespace: the room mapping, the already-synced target
+	// post, and the reactor's user mapping (so no ghost creation is needed).
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerAID, roomA), []byte(channelID)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixEventPostKey(multiServerAID, targetEventID), []byte(postID)))
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildMatrixUserKey(multiServerAID, reactor), []byte(reactorMMUserID)))
+
+	suite.api.On("GetUser", reactorMMUserID).Return(&model.User{Id: reactorMMUserID, Username: "reactor"}, nil).Maybe()
+	suite.api.On("GetChannel", channelID).Return(&model.Channel{Id: channelID, TeamId: ""}, nil).Maybe()
+	var addedReaction *model.Reaction
+	suite.api.On("AddReaction", mock.AnythingOfType("*model.Reaction")).Return(func(r *model.Reaction) *model.Reaction {
+		addedReaction = r
+		return r
+	}, nil).Maybe()
+
+	reaction := MatrixEvent{
+		Type:    "m.reaction",
+		EventID: reactionEventID,
+		Sender:  reactor,
+		RoomID:  roomA,
+		Content: map[string]any{
+			"m.relates_to": map[string]any{
+				"rel_type": "m.annotation",
+				"event_id": targetEventID,
+				"key":      "👍",
+			},
+		},
+		Timestamp: 2,
+	}
+
+	// Presented as server A: the reaction resolves the target post and is stored
+	// under server A's namespace.
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerA.HSToken, "txn-reaction-a", []MatrixEvent{reaction}))
+	require.NotNil(t, addedReaction, "server A reaction should be applied")
+	assert.Equal(t, postID, addedReaction.PostId)
+
+	stored, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixReactionKey(multiServerAID, reactionEventID))
+	require.NoError(t, err)
+	assert.NotEmpty(t, stored, "reaction mapping should be stored under server A")
+
+	// Presented as server B: the target post is not in server B's namespace, so the
+	// reaction does not resolve and nothing is stored under server B.
+	addedReaction = nil
+	require.NoError(t, suite.plugin.kvstore.Set(kvstore.BuildRoomMappingKey(multiServerBID, roomA), []byte(channelID)))
+	require.Equal(t, http.StatusOK, suite.putTransaction(suite.containerB.HSToken, "txn-reaction-b", []MatrixEvent{reaction}))
+	assert.Nil(t, addedReaction, "server B cannot resolve the target post, so no reaction is applied")
+
+	storedB, err := suite.plugin.kvstore.Get(kvstore.BuildMatrixReactionKey(multiServerBID, reactionEventID))
+	require.NoError(t, err)
+	assert.Empty(t, storedB, "server B namespace must not hold a reaction mapping")
 }
 
 func TestMultiServerIntegrationSuite(t *testing.T) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -233,6 +233,27 @@ func (p *Plugin) initBridges() {
 	p.matrixToMattermostBridge = NewMatrixToMattermostBridge(sharedUtils)
 }
 
+// newMatrixToMattermostBridge builds an inbound bridge scoped to a specific
+// serverID, carrying that server's Matrix client and KV namespace. Inbound
+// webhook traffic is routed to the originating homeserver (resolved from its
+// hs_token), so the bridge that handles an event must be bound to that server
+// rather than the single default one. Constructed on demand, mirroring the
+// per-call bridge construction in createDMChannelForGhostUser.
+func (p *Plugin) newMatrixToMattermostBridge(serverID string) *MatrixToMattermostBridge {
+	utils := NewBridgeUtils(BridgeUtilsConfig{
+		Logger:              p.logger,
+		API:                 p.API,
+		KVStore:             p.kvstore,
+		MatrixClient:        p.getMatrixClient(serverID),
+		ServerID:            serverID,
+		RemoteID:            p.remoteID,
+		MaxProfileImageSize: p.maxProfileImageSize,
+		MaxFileSize:         p.maxFileSize,
+		ConfigGetter:        p,
+	})
+	return NewMatrixToMattermostBridge(utils)
+}
+
 func (p *Plugin) registerForSharedChannels() error {
 	// Get the bot user ID or use a system admin
 	botUser, err := p.API.GetUserByUsername("mattermost-bridge")
@@ -276,6 +297,13 @@ func (p *Plugin) registerForSharedChannels() error {
 // GetMatrixClient returns the Matrix client for the single configured server.
 func (p *Plugin) GetMatrixClient() *matrix.Client {
 	return p.getMatrixClient(p.getSingleServerID())
+}
+
+// GetMatrixClientForServer returns the Matrix client for the given serverID, or
+// nil if none is registered. It lets commands operate on a specific server (e.g.
+// mapping a channel to a room on an injected server).
+func (p *Plugin) GetMatrixClientForServer(serverID string) *matrix.Client {
+	return p.getMatrixClient(serverID)
 }
 
 // GetServerID returns the serverID of the single configured Matrix server.

--- a/server/servers.go
+++ b/server/servers.go
@@ -53,6 +53,28 @@ func (p *Plugin) getSingleServerID() string {
 	return servers[0].ServerID
 }
 
+// serverDomainForID returns the raw homeserver domain (hostname, not the
+// property-key-sanitized form) for the given serverID, resolved from the managed
+// server registry. It is used to recognize this server's ghost users, whose IDs
+// end in ":<domain>". The bool is false when the server is unknown or its URL
+// cannot be parsed.
+func (p *Plugin) serverDomainForID(serverID string) (string, bool) {
+	servers, err := p.getServers()
+	if err != nil {
+		p.logger.LogWarn("Failed to read server registry while resolving server domain", "server_id", serverID, "error", err)
+		return "", false
+	}
+	server, ok := kvstore.ServerConfigForID(servers, serverID)
+	if !ok {
+		return "", false
+	}
+	domain, err := matrix.ExtractServerDomain(server.ServerURL)
+	if err != nil || domain == "" {
+		return "", false
+	}
+	return domain, true
+}
+
 // serverIDNamespace returns the "<serverID>_" prefix used to namespace per-server
 // KV keys, or "" when no server is registered yet. Migrations use it to detect
 // keys already migrated to the v3 layout.
@@ -99,12 +121,22 @@ func (p *Plugin) reconcileServerConfig() ([]kvstore.ServerConfig, error) {
 		return nil, err
 	}
 
+	// The primary entry is the one derived from the flat plugin.json config. Find
+	// any previously persisted primary (an entry that is not an injected extra) to
+	// carry its RemoteID forward and to warn when the hostname changes.
+	var persistedPrimary *kvstore.ServerConfig
+	for i := range existing {
+		if !existing[i].Injected {
+			persistedPrimary = &existing[i]
+			break
+		}
+	}
 	persistedRemoteID := ""
-	if len(existing) > 0 {
-		persistedRemoteID = existing[0].RemoteID
-		if existing[0].ServerID != serverID {
+	if persistedPrimary != nil {
+		persistedRemoteID = persistedPrimary.RemoteID
+		if persistedPrimary.ServerID != serverID {
 			p.logger.LogWarn("Matrix homeserver hostname changed; KV records under the previous serverID are now orphaned and can be recovered by reverting the server URL",
-				"previous_server_id", existing[0].ServerID, "new_server_id", serverID)
+				"previous_server_id", persistedPrimary.ServerID, "new_server_id", serverID)
 		}
 	}
 
@@ -127,7 +159,19 @@ func (p *Plugin) reconcileServerConfig() ([]kvstore.ServerConfig, error) {
 		Enabled:        config.EnableSync,
 		RemoteID:       remoteID,
 	}
+
+	// The flat plugin.json config describes only the primary server. Rebuild the
+	// primary entry and preserve any injected extra servers (added via
+	// `/matrix server add` for local multi-server testing). Non-injected entries
+	// are the previous primary and are always replaced, so a normal single-server
+	// install collapses to the same single-element list as before — no behavior
+	// change regardless of whether the serverID cache is warm.
 	servers := []kvstore.ServerConfig{entry}
+	for _, s := range existing {
+		if s.Injected && s.ServerID != serverID {
+			servers = append(servers, s)
+		}
+	}
 
 	data, err := json.Marshal(servers)
 	if err != nil {
@@ -142,6 +186,124 @@ func (p *Plugin) reconcileServerConfig() ([]kvstore.ServerConfig, error) {
 	p.matrixClientsLock.Unlock()
 
 	return servers, nil
+}
+
+// persistServers marshals and stores the managed server registry.
+func (p *Plugin) persistServers(servers []kvstore.ServerConfig) error {
+	data, err := json.Marshal(servers)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal servers_config")
+	}
+	if err := p.kvstore.Set(kvstore.KeyServersConfig, data); err != nil {
+		return errors.Wrap(err, "failed to persist servers_config")
+	}
+	return nil
+}
+
+// GetManagedServers returns the current managed Matrix server registry.
+func (p *Plugin) GetManagedServers() ([]kvstore.ServerConfig, error) {
+	return p.getServers()
+}
+
+// AddManagedServer upserts a Matrix server into the managed registry and rebuilds
+// the live client and bridge set so the server is usable without a restart. It
+// backs the `/matrix server add` admin command, which exists because the System
+// Console UI cannot yet manage more than one server. The serverID is derived from
+// serverURL (see deriveServerID), so adding a URL whose hostname matches an
+// existing server updates that entry in place. reconcileServerConfig preserves
+// this entry across future config changes because it is now part of the persisted
+// registry.
+func (p *Plugin) AddManagedServer(serverURL, serverName, asToken, hsToken, usernamePrefix string) (string, error) {
+	serverURL = strings.TrimSpace(serverURL)
+	serverID, err := deriveServerID(serverURL)
+	if err != nil {
+		return "", err
+	}
+
+	servers, err := p.getServers()
+	if err != nil {
+		return "", err
+	}
+
+	if usernamePrefix == "" {
+		usernamePrefix = DefaultMatrixUsernamePrefix
+	}
+	entry := kvstore.ServerConfig{
+		ServerID:       serverID,
+		ServerURL:      serverURL,
+		ServerName:     serverName,
+		ASToken:        asToken,
+		HSToken:        hsToken,
+		UsernamePrefix: usernamePrefix,
+		Enabled:        true,
+		RemoteID:       p.remoteID,
+		Injected:       true,
+	}
+
+	replaced := false
+	for i := range servers {
+		if servers[i].ServerID == serverID {
+			// Keep the existing RemoteID so re-adding a server does not drop its
+			// shared-channels registration.
+			if servers[i].RemoteID != "" {
+				entry.RemoteID = servers[i].RemoteID
+			}
+			servers[i] = entry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		servers = append(servers, entry)
+	}
+
+	if err := p.persistServers(servers); err != nil {
+		return "", err
+	}
+
+	// Rebuild the client registry and bridges from the updated registry so the new
+	// server is live immediately.
+	if err := p.initMatrixClient(); err != nil {
+		return "", errors.Wrap(err, "failed to rebuild Matrix clients after adding server")
+	}
+	p.initBridges()
+
+	return serverID, nil
+}
+
+// RemoveManagedServer removes a server from the managed registry by serverID and
+// rebuilds the live client and bridge set. It returns false if no entry matched.
+// Removing the primary server derived from the flat plugin.json configuration does
+// not persist: reconcileServerConfig re-adds it on the next rebuild.
+func (p *Plugin) RemoveManagedServer(serverID string) (bool, error) {
+	servers, err := p.getServers()
+	if err != nil {
+		return false, err
+	}
+
+	filtered := make([]kvstore.ServerConfig, 0, len(servers))
+	found := false
+	for _, s := range servers {
+		if s.ServerID == serverID {
+			found = true
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	if !found {
+		return false, nil
+	}
+
+	if err := p.persistServers(filtered); err != nil {
+		return false, err
+	}
+
+	if err := p.initMatrixClient(); err != nil {
+		return true, errors.Wrap(err, "failed to rebuild Matrix clients after removing server")
+	}
+	p.initBridges()
+
+	return true, nil
 }
 
 // serverIDEncoding matches model.NewId()'s base32 alphabet so a derived serverID

--- a/server/servers_test.go
+++ b/server/servers_test.go
@@ -4,11 +4,27 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-plugin-matrix-bridge/server/store/kvstore"
 )
+
+// stubAllLogging registers permissive stubs for every plugin-API log method across
+// the arities used by the code under test, so a stray log call never panics the mock.
+func stubAllLogging(api *plugintest.API) {
+	for _, level := range []string{"LogDebug", "LogInfo", "LogWarn", "LogError"} {
+		for n := 1; n <= 12; n++ {
+			args := make([]any, n)
+			for i := range args {
+				args[i] = mock.Anything
+			}
+			api.On(level, args...).Maybe()
+		}
+	}
+}
 
 func TestReconcileServerConfig(t *testing.T) {
 	t.Run("MintsAndDerivesFieldsFromFlatConfig", func(t *testing.T) {
@@ -151,6 +167,44 @@ func TestReconcileServerConfig(t *testing.T) {
 		assert.False(t, second[0].Enabled)
 	})
 
+	t.Run("PreservesInjectedServersAcrossReconcile", func(t *testing.T) {
+		plugin := setupPluginForTest()
+		plugin.kvstore = NewMemoryKVStore()
+		plugin.logger = &testLogger{t: t}
+		plugin.configuration = &configuration{MatrixServerURL: "https://a.example.com", EnableSync: true}
+
+		// Establish the primary, then persist an injected extra server alongside it.
+		first, err := plugin.reconcileServerConfig()
+		require.NoError(t, err)
+		require.Len(t, first, 1)
+		primaryID := first[0].ServerID
+
+		injected := kvstore.ServerConfig{ServerID: "injected01injected01inject1", ServerURL: "https://b.example.com", ServerName: "b.example.com", HSToken: "hs-b", Enabled: true, Injected: true}
+		require.NoError(t, plugin.persistServers(append(first, injected)))
+
+		// A later reconcile (warm cache) keeps the injected server and refreshes the primary.
+		second, err := plugin.reconcileServerConfig()
+		require.NoError(t, err)
+		require.Len(t, second, 2)
+		assert.Equal(t, primaryID, second[0].ServerID, "primary stays first")
+		assert.False(t, second[0].Injected)
+		assert.Equal(t, "injected01injected01inject1", second[1].ServerID, "injected server preserved")
+		assert.True(t, second[1].Injected)
+
+		// A cold reconcile (cleared cache) still preserves the injected server, and a
+		// primary URL change replaces only the primary — the injected extra survives.
+		plugin.serverID = ""
+		plugin.configuration = &configuration{MatrixServerURL: "https://c.example.com", EnableSync: true}
+		third, err := plugin.reconcileServerConfig()
+		require.NoError(t, err)
+		require.Len(t, third, 2)
+		newPrimaryID, err := deriveServerID("https://c.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, newPrimaryID, third[0].ServerID)
+		assert.NotEqual(t, primaryID, third[0].ServerID, "old primary replaced, not preserved")
+		assert.Equal(t, "injected01injected01inject1", third[1].ServerID, "injected server still preserved after primary URL change")
+	})
+
 	t.Run("DoesNotMintOnReadError", func(t *testing.T) {
 		base := NewMemoryKVStore()
 		plugin := setupPluginForTest()
@@ -199,6 +253,123 @@ func TestReconcileServerConfig(t *testing.T) {
 // TestDeriveServerID verifies the deterministic serverID derivation: same
 // hostname (regardless of scheme/port/path/case) yields the same 26-char base32
 // ID, distinct hostnames yield distinct IDs, and an unusable URL errors.
+func TestManagedServers(t *testing.T) {
+	const primaryURL = "https://primary.example.com"
+	const extraURL = "https://extra.example.com"
+
+	newPlugin := func(t *testing.T) *Plugin {
+		t.Helper()
+		api := &plugintest.API{}
+		stubAllLogging(api)
+		plugin := &Plugin{}
+		plugin.SetAPI(api)
+		plugin.logger = &testLogger{t: t}
+		plugin.kvstore = NewMemoryKVStore()
+		plugin.remoteID = "rid-primary"
+		plugin.configuration = &configuration{MatrixServerURL: primaryURL, EnableSync: true}
+		return plugin
+	}
+
+	t.Run("AddStampsInjectedAndSurvivesReconcile", func(t *testing.T) {
+		plugin := newPlugin(t)
+
+		serverID, err := plugin.AddManagedServer(extraURL, "extra.example.com", "as-x", "hs-x", "mx")
+		require.NoError(t, err)
+		expectedID, err := deriveServerID(extraURL)
+		require.NoError(t, err)
+		assert.Equal(t, expectedID, serverID, "serverID is derived from the URL hostname")
+
+		servers, err := plugin.GetManagedServers()
+		require.NoError(t, err)
+		require.Len(t, servers, 2, "primary plus the injected extra")
+
+		extra, ok := kvstore.ServerConfigForID(servers, serverID)
+		require.True(t, ok)
+		assert.True(t, extra.Injected, "an added server is marked injected")
+		assert.Equal(t, "hs-x", extra.HSToken)
+		assert.Equal(t, "as-x", extra.ASToken)
+		assert.Equal(t, "mx", extra.UsernamePrefix)
+		assert.True(t, extra.Enabled)
+
+		// A later reconcile (driven by any config change) must not drop the injected
+		// server: the Injected flag is exactly what makes it survive.
+		reconciled, err := plugin.reconcileServerConfig()
+		require.NoError(t, err)
+		_, stillThere := kvstore.ServerConfigForID(reconciled, serverID)
+		assert.True(t, stillThere, "injected server survives reconcile")
+	})
+
+	t.Run("AddUpsertsInPlaceAndPreservesRemoteID", func(t *testing.T) {
+		plugin := newPlugin(t)
+
+		serverID, err := plugin.AddManagedServer(extraURL, "extra.example.com", "as-1", "hs-1", "mx")
+		require.NoError(t, err)
+
+		// Give the injected entry a distinct RemoteID, as a real shared-channels
+		// registration would.
+		servers, err := plugin.getServers()
+		require.NoError(t, err)
+		for i := range servers {
+			if servers[i].ServerID == serverID {
+				servers[i].RemoteID = "preserved-rid"
+			}
+		}
+		require.NoError(t, plugin.persistServers(servers))
+
+		// Re-adding the same URL updates fields in place and keeps the RemoteID.
+		_, err = plugin.AddManagedServer(extraURL, "extra.example.com", "as-2", "hs-2", "mx2")
+		require.NoError(t, err)
+
+		after, err := plugin.GetManagedServers()
+		require.NoError(t, err)
+		assert.Len(t, after, 2, "re-adding the same server does not create a duplicate")
+		extra, ok := kvstore.ServerConfigForID(after, serverID)
+		require.True(t, ok)
+		assert.Equal(t, "hs-2", extra.HSToken, "tokens are updated in place")
+		assert.Equal(t, "preserved-rid", extra.RemoteID, "existing RemoteID is preserved on re-add")
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		plugin := newPlugin(t)
+		serverID, err := plugin.AddManagedServer(extraURL, "extra.example.com", "as", "hs", "mx")
+		require.NoError(t, err)
+
+		// Removing an injected server drops it.
+		removed, err := plugin.RemoveManagedServer(serverID)
+		require.NoError(t, err)
+		assert.True(t, removed)
+		servers, err := plugin.GetManagedServers()
+		require.NoError(t, err)
+		_, present := kvstore.ServerConfigForID(servers, serverID)
+		assert.False(t, present, "injected server is removed")
+
+		// Removing an unknown server reports not-found.
+		removed, err = plugin.RemoveManagedServer("no-such-server")
+		require.NoError(t, err)
+		assert.False(t, removed)
+	})
+
+	t.Run("RemovePrimaryReappearsAfterReconcile", func(t *testing.T) {
+		plugin := newPlugin(t)
+		// Establish the primary.
+		_, err := plugin.reconcileServerConfig()
+		require.NoError(t, err)
+		primaryID, err := deriveServerID(primaryURL)
+		require.NoError(t, err)
+
+		removed, err := plugin.RemoveManagedServer(primaryID)
+		require.NoError(t, err)
+		assert.True(t, removed, "the primary entry is found and removed")
+
+		// RemoveManagedServer rebuilds via reconcile, which re-derives the primary
+		// from the flat config, so it comes back.
+		servers, err := plugin.GetManagedServers()
+		require.NoError(t, err)
+		_, present := kvstore.ServerConfigForID(servers, primaryID)
+		assert.True(t, present, "the primary is re-added from the flat configuration")
+	})
+}
+
 func TestDeriveServerID(t *testing.T) {
 	const base32Alphabet = "ybndrfg8ejkmcpqxot1uwisza345h769"
 

--- a/server/store/kvstore/kvstore.go
+++ b/server/store/kvstore/kvstore.go
@@ -7,6 +7,11 @@ type KVStore interface {
 	GetTemplateData(userID string) (string, error)
 	Get(key string) ([]byte, error)
 	Set(key string, value []byte) error
+	// SetAtomicWithRetries reads the current value for key, passes it to valueFunc
+	// to compute the new value, and writes it back using compare-and-set semantics,
+	// retrying on conflict. This makes a read-modify-write on a shared key safe
+	// against concurrent writers. valueFunc receives nil when the key is absent.
+	SetAtomicWithRetries(key string, valueFunc func(oldValue []byte) (newValue []byte, err error)) error
 	Delete(key string) error
 	ListKeys(page, perPage int) ([]string, error)
 	ListKeysWithPrefix(page, perPage int, prefix string) ([]string, error)

--- a/server/store/kvstore/schema.go
+++ b/server/store/kvstore/schema.go
@@ -32,6 +32,11 @@ type ServerConfig struct {
 	// RemoteID is the shared-channels remote identifier, currently the single
 	// global remoteID returned by RegisterPluginForSharedChannels.
 	RemoteID string `json:"remote_id"`
+	// Injected marks a server added out-of-band (via the `/matrix server add`
+	// admin command for local multi-server testing) rather than derived from the
+	// flat plugin.json configuration. reconcileServerConfig preserves injected
+	// entries and always rebuilds the single non-injected primary.
+	Injected bool `json:"injected,omitempty"`
 }
 
 // ChannelServerMapping is one element of the value stored under a

--- a/server/store/kvstore/startertemplate.go
+++ b/server/store/kvstore/startertemplate.go
@@ -49,6 +49,20 @@ func (kv Client) Set(key string, value []byte) error {
 	return nil
 }
 
+// SetAtomicWithRetries reads the current value for key, computes the new value
+// via valueFunc, and writes it back using compare-and-set semantics, retrying on
+// conflict. It delegates to the plugin API's SetAtomicWithRetries, which stores
+// the returned byte slice as the raw value.
+func (kv Client) SetAtomicWithRetries(key string, valueFunc func(oldValue []byte) (newValue []byte, err error)) error {
+	err := kv.client.KV.SetAtomicWithRetries(key, func(oldValue []byte) (any, error) {
+		return valueFunc(oldValue)
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to atomically set key in KV store")
+	}
+	return nil
+}
+
 // Delete removes a key-value pair from the KV store.
 func (kv Client) Delete(key string) error {
 	appErr := kv.client.KV.Delete(key)

--- a/server/sync_to_mattermost.go
+++ b/server/sync_to_mattermost.go
@@ -143,10 +143,10 @@ func (b *MatrixToMattermostBridge) syncMatrixMessageToMattermost(event MatrixEve
 		Props:     make(map[string]any),
 	}
 
-	// Store Matrix event ID in post properties for reaction mapping and edit tracking
-	config := b.getConfiguration()
-	serverDomain := extractServerDomain(b.logger, config.MatrixServerURL)
-	propertyKey := "matrix_event_id_" + serverDomain
+	// Store Matrix event ID in post properties for reaction mapping and edit tracking.
+	// The domain is resolved per-server so events from different homeservers get
+	// distinct property keys.
+	propertyKey := "matrix_event_id_" + b.serverDomain()
 	post.Props[propertyKey] = event.EventID
 	post.Props["from_matrix"] = true
 
@@ -281,10 +281,10 @@ func (b *MatrixToMattermostBridge) syncMatrixFileToMattermost(event MatrixEvent,
 		Props:     make(map[string]any),
 	}
 
-	// Store Matrix event ID in post properties for reaction mapping and edit tracking
-	config := b.getConfiguration()
-	serverDomain := extractServerDomain(b.logger, config.MatrixServerURL)
-	propertyKey := "matrix_event_id_" + serverDomain
+	// Store Matrix event ID in post properties for reaction mapping and edit tracking.
+	// The domain is resolved per-server so events from different homeservers get
+	// distinct property keys.
+	propertyKey := "matrix_event_id_" + b.serverDomain()
 	post.Props[propertyKey] = event.EventID
 	post.Props["from_matrix"] = true
 

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -327,6 +327,29 @@ func (m *MemoryKVStore) Set(key string, value []byte) error {
 	return nil
 }
 
+// SetAtomicWithRetries performs a read-modify-write under the store's write lock,
+// which is atomic within this single-process test double, so no retry is needed.
+func (m *MemoryKVStore) SetAtomicWithRetries(key string, valueFunc func(oldValue []byte) (newValue []byte, err error)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var old []byte
+	if data, exists := m.data[key]; exists {
+		old = make([]byte, len(data))
+		copy(old, data)
+	}
+
+	newValue, err := valueFunc(old)
+	if err != nil {
+		return err
+	}
+
+	data := make([]byte, len(newValue))
+	copy(data, newValue)
+	m.data[key] = data
+	return nil
+}
+
 // Delete removes a key-value pair from the KV store.
 func (m *MemoryKVStore) Delete(key string) error {
 	m.mu.Lock()


### PR DESCRIPTION
## Summary

Phase 2 of multi-Matrix-server support ([MM-64622](https://mattermost.atlassian.net/browse/MM-64622)): route **inbound** Matrix Application Service traffic to the correct server. Each managed homeserver has its own `hs_token`; the presented bearer token is matched against every server's token to resolve the `serverID`, and all lookups/persistence happen in that server's KV namespace.

Builds on Phase 1 (config/client registry, namespaced KV). Single-server installs behave exactly as before.

## Changes

- **Auth middleware** (`server/api.go`): match the presented `Bearer` token against every server's `HSToken` (constant-time, full scan), resolve `serverID`, and inject it into the request context. Keeps the global `enable_sync` check plus a per-server `Enabled` check; unknown/invalid token → 401.
- **Transaction dedup** (`server/matrix_webhook.go`): key `processedTransactions` by `(serverID, txnID)` instead of `txnID` alone — Matrix `txnID`s are only unique per homeserver, so colliding IDs across servers no longer dedupe against each other.
- **Event routing** (`server/matrix_webhook.go`): thread `serverID` through `processMatrixEvent`; room-mapping and fallback room-state lookups use the resolved server's namespace and client from the registry.
- **Ghost-user detection**: check the user-ID suffix against the resolved server's domain rather than the single global config.
- **Inbound persistence** (`server/sync_to_mattermost.go`, `server/bridge_utils.go`): all `matrix_user_`, `mattermost_user_`, `matrix_event_post_`, `matrix_reaction_` reads/writes are namespaced by `serverID`; post property stored as `matrix_event_id_<serverDomain>`.
- **`/matrix server` command** (`server/command/command.go`): admin-only subcommands (`list`/`add`/`remove`/`map`) to register additional servers directly for local multi-server testing, since the System Console UI can't yet manage more than one server.
- **Local dev tooling**: second Synapse/Element stack in `docker-compose.yml` (+ configs), and a `docs/local-development.md` guide.
- **Tests**: two-server unit + integration tests covering namespace isolation, per-`(serverID, txnID)` dedup, unchanged single-server behavior, and unknown-token 401.

## Acceptance criteria

- Inbound events from server A never read/write server B's namespace.
- Duplicate detection is per `(serverID, txnID)`.
- One-server installs behave exactly as before.
